### PR TITLE
1. 增加 k8s 部署及说明 2. executor 不需要引入servlet容器，引入spring-boot-starter 即可，netty server 的启动线程设置为非守护线程 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,11 @@
 
 /datax-executor/target/
-/datax-executor/datax-executor.iml
-/datax-core/datax-core.iml
 /datax-core/target/
-/datax-admin/datax-admin.iml
 /datax-admin/target/
 /.idea/
 /datax-admin/.idea/
 /datax-registry/datax-registry.iml
 /datax-registry/target/
-/datax-rpc/datax-rpc.iml
 /datax-rpc/target/
 /datax-all.iml
 /logs/
@@ -18,3 +14,4 @@
 /build/
 /packages/
 /datax-assembly/target/
+*.iml

--- a/datax-executor/pom.xml
+++ b/datax-executor/pom.xml
@@ -29,7 +29,7 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter</artifactId>
         </dependency>
 
         <dependency>

--- a/datax-executor/src/main/resources/application.yml
+++ b/datax-executor/src/main/resources/application.yml
@@ -14,7 +14,7 @@ datax:
     admin:
       ### datax admin address list, such as "http://address" or "http://address01,http://address02"
       addresses: http://127.0.0.1:8080
-      #addresses: http://127.0.0.1:${datax.admin.port}
+      #addresses: http://${datax.admin.host:127.0.0.1}:${datax.admin.port}
     executor:
       appname: datax-executor
       ip:

--- a/datax-rpc/src/main/java/com/wugui/datax/rpc/remoting/net/Server.java
+++ b/datax-rpc/src/main/java/com/wugui/datax/rpc/remoting/net/Server.java
@@ -2,69 +2,20 @@ package com.wugui.datax.rpc.remoting.net;
 
 import com.wugui.datax.rpc.remoting.net.params.BaseCallback;
 import com.wugui.datax.rpc.remoting.provider.XxlRpcProviderFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * server
  *
  * @author xuxueli 2015-11-24 20:59:49
  */
-public abstract class Server {
-	protected static final Logger logger = LoggerFactory.getLogger(Server.class);
+public interface Server {
 
+    void setStartedCallback(BaseCallback startedCallback);
 
-	private BaseCallback startedCallback;
-	private BaseCallback stopedCallback;
+    void setStopedCallback(BaseCallback stopedCallback);
 
-	public void setStartedCallback(BaseCallback startedCallback) {
-		this.startedCallback = startedCallback;
-	}
+    void start(final XxlRpcProviderFactory xxlRpcProviderFactory) throws Exception;
 
-	public void setStopedCallback(BaseCallback stopedCallback) {
-		this.stopedCallback = stopedCallback;
-	}
-
-
-	/**
-	 * start server
-	 *
-	 * @param xxlRpcProviderFactory
-	 * @throws Exception
-	 */
-	public abstract void start(final XxlRpcProviderFactory xxlRpcProviderFactory) throws Exception;
-
-	/**
-	 * callback when started
-	 */
-	public void onStarted() {
-		if (startedCallback != null) {
-			try {
-				startedCallback.run();
-			} catch (Exception e) {
-				logger.error(">>>>>>>>>>> xxl-rpc, server startedCallback error.", e);
-			}
-		}
-	}
-
-	/**
-	 * stop server
-	 *
-	 * @throws Exception
-	 */
-	public abstract void stop() throws Exception;
-
-	/**
-	 * callback when stoped
-	 */
-	public void onStopped() {
-		if (stopedCallback != null) {
-			try {
-				stopedCallback.run();
-			} catch (Exception e) {
-				logger.error(">>>>>>>>>>> xxl-rpc, server stopedCallback error.", e);
-			}
-		}
-	}
+    void stop() throws Exception;
 
 }

--- a/datax-rpc/src/main/java/com/wugui/datax/rpc/remoting/net/impl/AbstractServer.java
+++ b/datax-rpc/src/main/java/com/wugui/datax/rpc/remoting/net/impl/AbstractServer.java
@@ -1,0 +1,119 @@
+package com.wugui.datax.rpc.remoting.net.impl;
+
+import com.wugui.datax.rpc.remoting.net.Server;
+import com.wugui.datax.rpc.remoting.net.params.BaseCallback;
+import com.wugui.datax.rpc.remoting.provider.XxlRpcProviderFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * @author yangzhuangqiu
+ * @date 2020/7/9 12:27
+ */
+public abstract class AbstractServer implements Server {
+
+    protected static final Logger logger = LoggerFactory.getLogger(AbstractServer.class);
+
+    private BaseCallback startedCallback;
+    private BaseCallback stopedCallback;
+
+    private Thread thread;
+
+    private AtomicBoolean started = new AtomicBoolean(false);
+    private AtomicBoolean stopped = new AtomicBoolean(true);
+
+    @Override
+    public void setStartedCallback(BaseCallback startedCallback) {
+        this.startedCallback = startedCallback;
+    }
+
+    @Override
+    public void setStopedCallback(BaseCallback stopedCallback) {
+        this.stopedCallback = stopedCallback;
+    }
+
+
+    /**
+     * start server
+     *
+     * @param xxlRpcProviderFactory
+     * @throws Exception
+     */
+    @Override
+    public void start(final XxlRpcProviderFactory xxlRpcProviderFactory) throws Exception {
+        boolean success = started.compareAndSet(false, true);
+        if (!success) {
+            logger.info("Server is already start....");
+            return;
+        }
+
+        thread = new Thread(() -> {
+            startServer(xxlRpcProviderFactory);
+        });
+        thread.start();
+
+        Runtime.getRuntime().addShutdownHook(
+                new Thread(() -> {
+                    try {
+                        stop();
+                    } catch (Exception e) {
+                    }
+                }));
+        stopped.set(false);
+    }
+
+    protected abstract void startServer(XxlRpcProviderFactory xxlRpcProviderFactory);
+
+    /**
+     * callback when started
+     */
+    protected void onStarted() {
+        if (startedCallback != null) {
+            try {
+                startedCallback.run();
+            } catch (Exception e) {
+                logger.error(">>>>>>>>>>> xxl-rpc, server startedCallback error.", e);
+            }
+        }
+    }
+
+    /**
+     * stop server
+     *
+     * @throws Exception
+     */
+    @Override
+    public void stop() throws Exception {
+        boolean success = stopped.compareAndSet(false, true);
+        if (!success) {
+            logger.info("Server is already stop....");
+            return;
+        }
+        // destroy server thread
+        if (thread != null && thread.isAlive()) {
+            thread.interrupt();
+        }
+
+        // on stop
+        onStopped();
+        logger.info(">>>>>>>>>>> xxl-rpc remoting server destroy success.");
+
+        started.set(false);
+    }
+
+    /**
+     * callback when stoped
+     */
+    protected void onStopped() {
+        if (stopedCallback != null) {
+            try {
+                stopedCallback.run();
+            } catch (Exception e) {
+                logger.error(">>>>>>>>>>> xxl-rpc, server stopedCallback error.", e);
+            }
+        }
+    }
+
+}

--- a/datax-rpc/src/main/java/com/wugui/datax/rpc/remoting/net/impl/netty_http/server/NettyHttpServer.java
+++ b/datax-rpc/src/main/java/com/wugui/datax/rpc/remoting/net/impl/netty_http/server/NettyHttpServer.java
@@ -2,6 +2,7 @@ package com.wugui.datax.rpc.remoting.net.impl.netty_http.server;
 
 import com.wugui.datax.rpc.remoting.net.Server;
 import com.wugui.datax.rpc.remoting.net.common.NettyConstant;
+import com.wugui.datax.rpc.remoting.net.impl.AbstractServer;
 import com.wugui.datax.rpc.remoting.net.params.Beat;
 import com.wugui.datax.rpc.remoting.provider.XxlRpcProviderFactory;
 import com.wugui.datax.rpc.util.ThreadPoolUtil;
@@ -19,91 +20,73 @@ import io.netty.handler.timeout.IdleStateHandler;
 
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * netty_http
  *
  * @author xuxueli 2015-11-24 22:25:15
  */
-public class NettyHttpServer extends Server {
-
-    private Thread thread;
+public class NettyHttpServer extends AbstractServer {
 
     @Override
-    public void start(final XxlRpcProviderFactory xxlRpcProviderFactory) {
+    protected void startServer(XxlRpcProviderFactory xxlRpcProviderFactory) {
+        // param
+        final ThreadPoolExecutor serverHandlerPool = ThreadPoolUtil.makeServerThreadPool(
+                NettyHttpServer.class.getSimpleName(),
+                xxlRpcProviderFactory.getCorePoolSize(),
+                xxlRpcProviderFactory.getMaxPoolSize());
+        EventLoopGroup bossGroup = new NioEventLoopGroup();
+        EventLoopGroup workerGroup = new NioEventLoopGroup();
 
-        thread = new Thread(() -> {
-            // param
-            final ThreadPoolExecutor serverHandlerPool = ThreadPoolUtil.makeServerThreadPool(
-                    NettyHttpServer.class.getSimpleName(),
-                    xxlRpcProviderFactory.getCorePoolSize(),
-                    xxlRpcProviderFactory.getMaxPoolSize());
-            EventLoopGroup bossGroup = new NioEventLoopGroup();
-            EventLoopGroup workerGroup = new NioEventLoopGroup();
+        try {
+            // start server
+            ServerBootstrap bootstrap = new ServerBootstrap();
+            bootstrap.group(bossGroup, workerGroup)
+                    .channel(NioServerSocketChannel.class)
+                    .childHandler(new ChannelInitializer<SocketChannel>() {
+                        @Override
+                        public void initChannel(SocketChannel channel) {
+                            channel.pipeline()
+                                    .addLast(new IdleStateHandler(0, 0, Beat.BEAT_INTERVAL * 3, TimeUnit.SECONDS))  // beat 3N, close if idle
+                                    .addLast(new HttpServerCodec())
+                                    .addLast(new HttpObjectAggregator(NettyConstant.MAX_LENGTH))  // merge request & reponse to FULL
+                                    .addLast(new NettyHttpServerHandler(xxlRpcProviderFactory, serverHandlerPool));
+                        }
+                    })
+                    .childOption(ChannelOption.SO_KEEPALIVE, true);
 
-            try {
-                // start server
-                ServerBootstrap bootstrap = new ServerBootstrap();
-                bootstrap.group(bossGroup, workerGroup)
-                        .channel(NioServerSocketChannel.class)
-                        .childHandler(new ChannelInitializer<SocketChannel>() {
-                            @Override
-                            public void initChannel(SocketChannel channel) {
-                                channel.pipeline()
-                                        .addLast(new IdleStateHandler(0, 0, Beat.BEAT_INTERVAL * 3, TimeUnit.SECONDS))  // beat 3N, close if idle
-                                        .addLast(new HttpServerCodec())
-                                        .addLast(new HttpObjectAggregator(NettyConstant.MAX_LENGTH))  // merge request & reponse to FULL
-                                        .addLast(new NettyHttpServerHandler(xxlRpcProviderFactory, serverHandlerPool));
-                            }
-                        })
-                        .childOption(ChannelOption.SO_KEEPALIVE, true);
+            // bind
+            ChannelFuture future = bootstrap.bind(xxlRpcProviderFactory.getPort()).sync();
 
-                // bind
-                ChannelFuture future = bootstrap.bind(xxlRpcProviderFactory.getPort()).sync();
+            logger.info(">>>>>>>>>>> xxl-rpc remoting server start success, nettype = {}, port = {}", NettyHttpServer.class.getName(), xxlRpcProviderFactory.getPort());
+            onStarted();
 
-                logger.info(">>>>>>>>>>> xxl-rpc remoting server start success, nettype = {}, port = {}", NettyHttpServer.class.getName(), xxlRpcProviderFactory.getPort());
-                onStarted();
+            // wait util stop
+            future.channel().closeFuture().sync();
 
-                // wait util stop
-                future.channel().closeFuture().sync();
-
-            } catch (InterruptedException e) {
-                if (e instanceof InterruptedException) {
-                    logger.info(">>>>>>>>>>> xxl-rpc remoting server stop.");
-                } else {
-                    logger.error(">>>>>>>>>>> xxl-rpc remoting server error.", e);
-                }
-            } finally {
-
-                // stop
-                try {
-                    serverHandlerPool.shutdown();    // shutdownNow
-                } catch (Exception e) {
-                    logger.error(e.getMessage(), e);
-                }
-                try {
-                    workerGroup.shutdownGracefully();
-                    bossGroup.shutdownGracefully();
-                } catch (Exception e) {
-                    logger.error(e.getMessage(), e);
-                }
+        } catch (InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                logger.info(">>>>>>>>>>> xxl-rpc remoting server stop.");
+            } else {
+                logger.error(">>>>>>>>>>> xxl-rpc remoting server error.", e);
             }
+        } finally {
 
-        });
-        thread.setDaemon(true);    // daemon, service jvm, user thread leave >>> daemon leave >>> jvm leave
-        thread.start();
-    }
-
-    @Override
-    public void stop() {
-        // destroy server thread
-        if (thread != null && thread.isAlive()) {
-            thread.interrupt();
+            // stop
+            try {
+                serverHandlerPool.shutdown();    // shutdownNow
+            } catch (Exception e) {
+                logger.error(e.getMessage(), e);
+            }
+            try {
+                workerGroup.shutdownGracefully();
+                bossGroup.shutdownGracefully();
+            } catch (Exception e) {
+                logger.error(e.getMessage(), e);
+            }
         }
 
-        // on stop
-        onStopped();
-        logger.info(">>>>>>>>>>> xxl-rpc remoting server destroy success.");
     }
 
 }

--- a/datax-rpc/src/main/java/com/wugui/datax/rpc/remoting/net/params/BaseCallback.java
+++ b/datax-rpc/src/main/java/com/wugui/datax/rpc/remoting/net/params/BaseCallback.java
@@ -3,8 +3,8 @@ package com.wugui.datax.rpc.remoting.net.params;
 /**
  * @author xuxueli 2018-10-19
  */
-public abstract class BaseCallback {
+public interface BaseCallback {
 
-    public abstract void run() throws Exception;
+    void run() throws Exception;
 
 }

--- a/k8s/Dockerfile/datax-admin.Dockerfile
+++ b/k8s/Dockerfile/datax-admin.Dockerfile
@@ -1,0 +1,7 @@
+# docker build -t yangzhuangqiu/datax:admin-2.1.2 .
+FROM yangzhuangqiu/java:8u191-alpine
+LABEL MAINTAINER="yangzhuangqiu <yangzhuangqiu@qq.com>"
+WORKDIR /opt/
+ADD datax-admin_2.1.2_1.tar.gz /opt/
+
+ENTRYPOINT exec java $JAVA_OPTS -classpath /opt/datax-admin/lib/*:/opt/datax-admin/conf:. com.wugui.datax.admin.DataXAdminApplication

--- a/k8s/Dockerfile/datax-executor.Dockerfile
+++ b/k8s/Dockerfile/datax-executor.Dockerfile
@@ -1,0 +1,8 @@
+# docker build -t yangzhuangqiu/datax:executor-2.1.2  .
+FROM yangzhuangqiu/base:alpine-python2.7-java1.8
+LABEL MAINTAINER="yangzhuangqiu <yangzhuangqiu@qq.com>"
+WORKDIR /opt/
+ADD datax.tar.gz /opt/
+ADD datax-executor_2.1.2_1.tar.gz /opt/
+
+ENTRYPOINT exec java $JAVA_OPTS -classpath /opt/datax-executor/lib/*:/opt/datax-executor/conf:. com.wugui.datax.executor.DataXExecutorApplication

--- a/k8s/datax-admin-bootstrap-conf.yaml
+++ b/k8s/datax-admin-bootstrap-conf.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datax-admin-bootstrap-conf
+  labels:
+    app: datax-admin
+data:
+  bootstrap.properties: |
+    #Database
+    DB_HOST=svc-mysql.db.svc.cluster.local
+    DB_PORT=3306
+    DB_USERNAME=root
+    DB_PASSWORD=123456
+    DB_DATABASE=datax

--- a/k8s/deploy-datax-admin.yaml
+++ b/k8s/deploy-datax-admin.yaml
@@ -1,0 +1,112 @@
+# ingress
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: ing-datax-admin
+  namespace: default
+  annotations:
+    kubernetes.io/ingress.class: traefik
+spec:
+  rules:
+  - host: datax-web.xxx.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: svc-datax-admin
+          servicePort: web
+---
+# svc
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-datax-admin
+  namespace: default
+  labels:
+    app: svc-datax-admin
+spec:
+  selector:
+    app: datax-admin
+  ports:
+  - name: web
+    port: 9527
+    targetPort: web
+---
+# deploy
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: default
+  name: deploy-datax-admin
+  labels:
+    app: deploy-datax-admin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: datax-admin
+  revisionHistoryLimit: 2
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  template:
+    metadata:
+      namespace: default
+      labels:
+        app: datax-admin
+    spec:
+      containers:
+      - name: datax-admin
+        image: yangzhuangqiu/datax:admin-2.1.2
+        ports:
+        - containerPort: 9527
+          name: web
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 1024Mi
+          requests:
+            cpu: 200m
+            memory: 512Mi
+        livenessProbe:
+          httpGet:
+            path: /index.html
+            port: web
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: web
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 5
+        # 优雅退出
+        lifecycle:
+          preStop:
+            exec:
+              command: ["sleep", "15"]
+        volumeMounts:
+        - name: config
+          mountPath: /opt/datax-admin/conf/bootstrap.properties
+          subPath: bootstrap.properties
+          readOnly: true
+        env:
+        - name: SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: JAVA_OPTS
+          value: -server -Xmx512m -Xms512m -Duser.timezone=Asia/Shanghai -Dserver.port=9527 -Ddata.path=/opt/datax-admin/data -Dlogging.config=/opt/datax-admin/conf/logback.xml -Dmail.username=datax -Dmail.password=123456
+        - name: LOG_PATH
+          value: /opt/datax-admin/logs
+      securityContext:
+        runAsUser: 0
+      volumes:
+      - name: config
+        configMap:
+          defaultMode: 0600
+          name: datax-admin-bootstrap-conf

--- a/k8s/deploy-datax-executor.yaml
+++ b/k8s/deploy-datax-executor.yaml
@@ -1,0 +1,65 @@
+# deploy
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: default
+  name: deploy-datax-executor
+  labels:
+    app: deploy-datax-executor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: datax-executor
+  revisionHistoryLimit: 2
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      namespace: default
+      labels:
+        app: datax-executor
+    spec:
+      containers:
+      - name: datax-executor
+        image: yangzhuangqiu/datax:executor-2.1.2
+        ports:
+        - containerPort: 9999
+          name: executor
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 1024Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        livenessProbe:
+          tcpSocket:
+            port: executor
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 5
+        readinessProbe:
+          tcpSocket:
+            port: executor
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 5
+        lifecycle:
+          preStop:
+            exec:
+              command: ["sleep", "15"]
+        env:
+        - name: SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: JAVA_OPTS
+          value: -server -Xmx512m -Xms512m -Duser.timezone=Asia/Shanghai -Dserver.port=9504 -Dexecutor.port=9999 -Ddatax.admin.host=svc-datax-admin -Ddatax.admin.port=9527 -Dpython.path=/opt/datax/bin/datax.py -Ddata.path=/opt/datax-executor/data -Djson.path=/opt/datax-executor/json -Dlogging.config=/opt/datax-executor/conf/logback.xml
+        - name: LOG_PATH
+          value: /opt/datax-executor/logs
+      securityContext:
+        runAsUser: 0

--- a/k8s/readme.md
+++ b/k8s/readme.md
@@ -1,0 +1,15 @@
+## dockerfile
+将 admin 和 executor 分开构建和部署，executor 需要向 admin 注册，故需要增加 admin 的 host 配置项：datax.admin.host，类似 datax.admin.port，在 executor 模块的配置文件中
+
+
+## k8s 部署
+1. 准备好mysql，执行db下的sql脚本。（可在k8s安装mysql）
+2. 配置数据库信息 datax-admin-bootstrap-conf.yaml，然后执行 `kubectl apply -f datax-admin-bootstrap-conf.yaml`
+3. 启动 datax-admin: `kubectl apply -f deploy-datax-admin.yaml` 
+4. 启动 datax-executor: `kubectl apply -f deploy-datax-executor.yaml`
+
+> 说明：
+1. datax-admin 使用 ingress(traefik) 访问，可自行更改。 
+2. executor 启动数量可由 deploy-datax-executor.yaml 中 spec.replicas 更改
+3. executor 启动 netty server(需要更改代码，非守护线程)，本身并不需要 servlet 容器。不需要引入 spring-boot-starter-web ，引入 spring-boot-starter 即可，也就不需要 server.port 参数 
+


### PR DESCRIPTION
executor中并不需要servlet容器，而netty server 是通信核心，不应该随着其他非守护线程的退出而退出，其启动线程应该设置为非守护线程。当初设置成守护线程的动机是什么？