### PR TITLE
解决无法正常停止和运行脚本的日志路径无法起作用

### DIFF
--- a/datax-admin/src/main/bin/configure.sh
+++ b/datax-admin/src/main/bin/configure.sh
@@ -123,7 +123,7 @@ SERVER_NAME_SIMPLE=${SERVER_NAME/datax-/}
 LOG_PATH=${BIN}/../logs
 if [ "x${BASE_LOG_DIR}" != "x" ]; then
     LOG_PATH=${BASE_LOG_DIR}/${SERVER_NAME_SIMPLE}
-    sed -ri "s![#]?(WEB_LOG_PATH=)\S*!\1${LOG_PATH}!g" ${ENV_FILE_PATH}
+    sed -ri "s![#]?(SERVICE_LOG_PATH=)\S*!\1${LOG_PATH}!g" ${ENV_FILE_PATH}
 fi
 
 CONF_PATH=${BIN}/../conf

--- a/datax-admin/src/main/bin/datax-admin.sh
+++ b/datax-admin/src/main/bin/datax-admin.sh
@@ -217,7 +217,7 @@ stop_m(){
     LOG INFO "Killing ${FRIEND_NAME} (pid ${p}) ..."
     case "`uname`" in
         CYCGWIN*) taskkill /PID "${p}" ;;
-        *) kill -SIGTERM "${p}" ;;
+        *) kill -TERM "${p}" ;;
     esac
     LOG INFO "Waiting ${FRIEND_NAME} to stop complete ..."
     wait_for_stop 20

--- a/datax-admin/src/main/bin/env.properties
+++ b/datax-admin/src/main/bin/env.properties
@@ -2,7 +2,7 @@
 
 #JAVA_HOME=""
 
-WEB_LOG_PATH=${BIN}/../logs
+SERVICE_LOG_PATH=${BIN}/../logs
 WEB_CONF_PATH=${BIN}/../conf
 
 DATA_PATH=${BIN}/../data

--- a/datax-admin/src/main/resources/logback.xml
+++ b/datax-admin/src/main/resources/logback.xml
@@ -3,7 +3,7 @@
 
     <contextName>admin</contextName>
     <property name="LOG_PATH"
-              value="${LOG_PATH:-${LOG_TEMP:-${java.io.tmpdir:-/data/applogs/admin}}}"/>
+              value="${log.path:-${LOG_TEMP:-${java.io.tmpdir:-/data/applogs/admin}}}"/>
 
     <!--控制台日志， 控制台输出 -->
     <appender name="console" class="ch.qos.logback.core.ConsoleAppender">

--- a/datax-executor/src/main/bin/configure.sh
+++ b/datax-executor/src/main/bin/configure.sh
@@ -111,7 +111,7 @@ SERVER_NAME_SIMPLE=${SERVER_NAME/datax-/}
 LOG_PATH=${BIN}/../logs
 if [ "x${BASE_LOG_DIR}" != "x" ]; then
     LOG_PATH=${BASE_LOG_DIR}/${SERVER_NAME_SIMPLE}
-    sed -ri "s![#]?(WEB_LOG_PATH=)\S*!\1${LOG_PATH}!g" ${ENV_FILE_PATH}
+    sed -ri "s![#]?(SERVICE_LOG_PATH=)\S*!\1${LOG_PATH}!g" ${ENV_FILE_PATH}
 fi
 
 CONF_PATH=${BIN}/../conf

--- a/datax-executor/src/main/bin/datax-executor.sh
+++ b/datax-executor/src/main/bin/datax-executor.sh
@@ -227,7 +227,7 @@ stop_m(){
     LOG INFO "Killing ${FRIEND_NAME} (pid ${p}) ..."
     case "`uname`" in
         CYCGWIN*) taskkill /PID "${p}" ;;
-        *) kill -SIGTERM "${p}" ;;
+        *) kill -TERM "${p}" ;;
     esac
     LOG INFO "Waiting ${FRIEND_NAME} to stop complete ..."
     wait_for_stop 20

--- a/datax-executor/src/main/resources/logback.xml
+++ b/datax-executor/src/main/resources/logback.xml
@@ -3,7 +3,7 @@
 
     <contextName>exe</contextName>
     <property name="LOG_PATH"
-              value="${LOG_PATH:-${LOG_TEMP:-${java.io.tmpdir:-/data/applogs/executor/jobhandler}}}" />
+              value="${log.path:-${LOG_TEMP:-${java.io.tmpdir:-/data/applogs/executor/jobhandler}}}" />
 
     <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>


### PR DESCRIPTION
1. 修改admin和executor的脚本，解决无法正常停止
2. 修改logback.xml 解决脚本中配置的日志路径无法起作用