### PR TITLE
删除日志的冗余代码

### DIFF
--- a/datax-executor/src/main/java/com/wugui/datax/executor/core/config/DataXConfig.java
+++ b/datax-executor/src/main/java/com/wugui/datax/executor/core/config/DataXConfig.java
@@ -18,8 +18,6 @@ import org.springframework.context.annotation.Configuration;
 public class DataXConfig {
     private Logger logger = LoggerFactory.getLogger(DataXConfig.class);
 
-    private static final String DEFAULT_LOG_PATH = "log/executor/jobhandler";
-
     @Value("${datax.job.admin.addresses}")
     private String adminAddresses;
 
@@ -51,10 +49,6 @@ public class DataXConfig {
         jobSpringExecutor.setIp(ip);
         jobSpringExecutor.setPort(port);
         jobSpringExecutor.setAccessToken(accessToken);
-        String dataXHomePath = SystemUtils.getDataXHomePath();
-        if (StringUtils.isEmpty(logPath)) {
-            logPath = dataXHomePath + DEFAULT_LOG_PATH;
-        }
         jobSpringExecutor.setLogPath(logPath);
         jobSpringExecutor.setLogRetentionDays(logRetentionDays);
 


### PR DESCRIPTION
datax.job.executor. logpath: ${DATA_PATH:.}/applogs/executor/jobhandler
yml 已经这样配置了，那这个里面就不需要再判断isEmpty了。另外也应该用isBlank而非isEmpty判断

public static boolean isBlank(CharSequence cs) {
        int strLen;  
        if (cs != null && (strLen = cs.length()) != 0) {
            for(int i = 0; i < strLen; ++i) {
                if (!Character.isWhitespace(cs.charAt(i))) {
                    return false;
                }
            }
            return true;
        } else {
            return true;
        }
    }


isEmpty 不能过滤空格
