### PR TITLE
解决Oracle没有dba权限查询用户和表失败问题

### DIFF
--- a/datax-admin/src/main/java/com/wugui/datax/admin/tool/meta/OracleDatabaseMeta.java
+++ b/datax-admin/src/main/java/com/wugui/datax/admin/tool/meta/OracleDatabaseMeta.java
@@ -50,12 +50,12 @@ public class OracleDatabaseMeta extends BaseDatabaseMeta implements DatabaseInte
 
     @Override
     public String getSQLQueryTables(String... tableSchema) {
-        return "select table_name from dba_tables where owner='" + tableSchema[0] + "'";
+        return "select table_name from all_tables where owner='" + tableSchema[0] + "'";
     }
 
     @Override
     public String getSQLQueryTableSchema(String... args) {
-        return "select username from sys.dba_users";
+        return "select username from all_users";
     }
 
 


### PR DESCRIPTION
getSQLQueryTables方法sql中的dba_tables修改为all_tables。
getSQLQueryTableSchema方法sql中的dba_users修改为all_users。