### PR TITLE
解决Oracle没有dba权限查询用户和表失败问题 和 添加表名称处理函数

### DIFF
--- a/datax-admin/src/main/java/com/wugui/datax/admin/tool/meta/OracleDatabaseMeta.java
+++ b/datax-admin/src/main/java/com/wugui/datax/admin/tool/meta/OracleDatabaseMeta.java
@@ -50,12 +50,12 @@ public class OracleDatabaseMeta extends BaseDatabaseMeta implements DatabaseInte
 
     @Override
     public String getSQLQueryTables(String... tableSchema) {
-        return "select table_name from dba_tables where owner='" + tableSchema[0] + "'";
+        return "select table_name from all_tables where owner='" + tableSchema[0] + "'";
     }
 
     @Override
     public String getSQLQueryTableSchema(String... args) {
-        return "select username from sys.dba_users";
+        return "select username from all_users";
     }
 
 

--- a/doc/datax-web/increment-desc.md
+++ b/doc/datax-web/increment-desc.md
@@ -129,7 +129,7 @@ select * from test_list where operationDate >= FROM_UNIXTIME(${lastTime}) and op
 
 ```
 1.-D是DataX参数的标识符，必配
-2.-D后面的startId和endId是DataX json中where条件的id字段标识符，必须和json中的变量名称保持一致
+2.-D后面的startId和endId是DataX json中where条件的id字段标识符，必须和json中的变量名称保持一致，endId是任务在每次执行时获取当前表maxId，也是下一次任务的startId
 3.='%s'是项目用来去替换时间的占位符，比配并且格式要完全一致
 4.注意-DstartId='%s'和-DendId='%s' 中间有一个空格，空格必须保留并且是一个空格
 5.reader数据源，选择任务同步的读数据源


### PR DESCRIPTION
解决Oracle没有dba权限查询用户和表失败问题
getSQLQueryTables方法sql中的dba_tables修改为all_tables。
getSQLQueryTableSchema方法sql中的dba_users修改为all_users。

添加表名称处理函数
针对Oracle和PostgreSQL数据库的表名称大小写敏感问题。
建议需要查询表数据的函数（包括json构建的函数），可以先调用这个函数处理下表名称。