### PR TITLE
添加mongodb主键自增类型

### DIFF
--- a/datax-admin/src/main/java/com/wugui/datax/admin/core/trigger/JobTrigger.java
+++ b/datax-admin/src/main/java/com/wugui/datax/admin/core/trigger/JobTrigger.java
@@ -150,6 +150,9 @@ public class JobTrigger {
             triggerParam.setReplaceParamType(jobInfo.getReplaceParamType());
         } else if (IncrementTypeEnum.PARTITION.getCode().equals(incrementType)) {
             triggerParam.setPartitionInfo(jobInfo.getPartitionInfo());
+        } else if (IncrementTypeEnum.MONGODB_ID.getCode().equals(incrementType)) {
+            triggerParam.setMongodbStartId(jobInfo.getMongodbIncStartId());
+            triggerParam.setTriggerTime(triggerTime);
         }
         triggerParam.setReplaceParam(jobInfo.getReplaceParam());
         //jvm parameter

--- a/datax-executor/pom.xml
+++ b/datax-executor/pom.xml
@@ -43,6 +43,12 @@
             <artifactId>datax-core</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongo-java-driver</artifactId>
+            <version>${mongo-java-driver.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/datax-executor/src/main/java/com/wugui/datax/executor/service/command/BuildCommand.java
+++ b/datax-executor/src/main/java/com/wugui/datax/executor/service/command/BuildCommand.java
@@ -6,6 +6,7 @@ import com.wugui.datatx.core.util.Constants;
 import com.wugui.datatx.core.util.DateUtil;
 import com.wugui.datax.executor.util.SystemUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.bson.types.ObjectId;
 
 import java.io.File;
 import java.text.SimpleDateFormat;
@@ -90,6 +91,13 @@ public class BuildCommand {
                     return getKeyValue(formatParam);
                 }
             }
+            // 这里是mongodb主键自增
+            if(IncrementTypeEnum.MONGODB_ID.getCode().equals(incrementType)){
+                String startId = tgParam.getMongodbStartId();
+                String endId = new ObjectId(tgParam.getTriggerTime()).toHexString();
+                String formatParam = String.format(replaceParam, startId, endId);
+                return getKeyValue(formatParam);
+            }
 
         }
 
@@ -120,6 +128,8 @@ public class BuildCommand {
 
         return map;
     }
+
+
 
 
     private void buildPartitionCM(StringBuilder doc, String partitionStr) {


### PR DESCRIPTION
1.增加mongodb主键自增类型同步。
前端的自增类型，需要增加mongodb主键自增类型。设计模式和ID增量类型相同。
前端页面有：增量主键开始ID、ID增量参数