### PR TITLE
Dev

### DIFF
--- a/datax-core/src/main/java/com/wugui/datatx/core/biz/model/TriggerParam.java
+++ b/datax-core/src/main/java/com/wugui/datatx/core/biz/model/TriggerParam.java
@@ -37,8 +37,27 @@ public class TriggerParam implements Serializable{
 
     private String partitionInfo;
 
+    public String getMongodbStartId() {
+        return mongodbStartId;
+    }
+
+    public void setMongodbStartId(String mongodbStartId) {
+        this.mongodbStartId = mongodbStartId;
+    }
+
+    public String getMongodbEndId() {
+        return mongodbEndId;
+    }
+
+    public void setMongodbEndId(String mongodbEndId) {
+        this.mongodbEndId = mongodbEndId;
+    }
+
     private long startId;
     private long endId;
+
+    private String mongodbStartId;
+    private String mongodbEndId;
 
     private Integer incrementType;
 

--- a/datax-core/src/main/java/com/wugui/datatx/core/biz/model/TriggerParam.java
+++ b/datax-core/src/main/java/com/wugui/datatx/core/biz/model/TriggerParam.java
@@ -45,13 +45,7 @@ public class TriggerParam implements Serializable{
         this.mongodbStartId = mongodbStartId;
     }
 
-    public String getMongodbEndId() {
-        return mongodbEndId;
-    }
 
-    public void setMongodbEndId(String mongodbEndId) {
-        this.mongodbEndId = mongodbEndId;
-    }
 
     private long startId;
     private long endId;
@@ -63,6 +57,14 @@ public class TriggerParam implements Serializable{
 
     private String replaceParamType;
 
+
+    public String getMongodbEndId() {
+        return mongodbEndId;
+    }
+
+    public void setMongodbEndId(String mongodbEndId) {
+        this.mongodbEndId = mongodbEndId;
+    }
 
     public int getJobId() {
         return jobId;

--- a/datax-core/src/main/java/com/wugui/datatx/core/enums/IncrementTypeEnum.java
+++ b/datax-core/src/main/java/com/wugui/datatx/core/enums/IncrementTypeEnum.java
@@ -12,11 +12,13 @@ public enum IncrementTypeEnum {
      * 1 ID
      * 3 PARTITION
      * 4 3 PARTITION AND TIME
+     * 5 MONGODB ID
      */
-    TIME(2, "时间"),
     ID(1, "自增主键"),
+    TIME(2, "时间"),
     PARTITION(3, "HIVE分区"),
-    PARTITION_TIME(4, "HIVE分区时间增量");
+    PARTITION_TIME(4, "HIVE分区时间增量"),
+    MONGODB_ID(5, "mongodb主键增量");
 
     IncrementTypeEnum(Integer code, String descp) {
         this.code = code;

--- a/datax-executor/pom.xml
+++ b/datax-executor/pom.xml
@@ -44,11 +44,7 @@
             <version>${project.parent.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.mongodb</groupId>
-            <artifactId>mongo-java-driver</artifactId>
-            <version>${mongo-java-driver.version}</version>
-        </dependency>
+ 
     </dependencies>
 
     <build>

--- a/datax-executor/src/main/java/com/wugui/datax/executor/service/command/BuildCommand.java
+++ b/datax-executor/src/main/java/com/wugui/datax/executor/service/command/BuildCommand.java
@@ -94,7 +94,7 @@ public class BuildCommand {
             // 这里是mongodb主键自增
             if(IncrementTypeEnum.MONGODB_ID.getCode().equals(incrementType)){
                 String startId = tgParam.getMongodbStartId();
-                String endId = new ObjectId(tgParam.getTriggerTime()).toHexString();
+                String endId = tgParam.getMongodbEndId();
                 String formatParam = String.format(replaceParam, startId, endId);
                 return getKeyValue(formatParam);
             }

--- a/datax-executor/src/main/java/com/wugui/datax/executor/service/command/BuildCommand.java
+++ b/datax-executor/src/main/java/com/wugui/datax/executor/service/command/BuildCommand.java
@@ -6,7 +6,6 @@ import com.wugui.datatx.core.util.Constants;
 import com.wugui.datatx.core.util.DateUtil;
 import com.wugui.datax.executor.util.SystemUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.bson.types.ObjectId;
 
 import java.io.File;
 import java.text.SimpleDateFormat;


### PR DESCRIPTION
1.增加mongodb主键自增类型同步。
前端的自增类型，需要增加mongodb主键自增类型。设计模式和ID增量类型相同。
前端页面有：增量主键开始ID、ID增量参数
2.只支持mongodb的ObjectId类型