### PR TITLE
fix: package conflict caused by jaspic

### DIFF
--- a/datax-admin/pom.xml
+++ b/datax-admin/pom.xml
@@ -422,6 +422,10 @@
                     <artifactId>log4j-slf4j-impl</artifactId>
                     <groupId>org.apache.logging.log4j</groupId>
                 </exclusion>
+                <exclusion>
+                    <artifactId>geronimo-jaspic_1.0_spec</artifactId>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
Fix package conflicts. This problem can cause exceptions when using container deployment,
and conflicts will occur when all jars are included in the classpath