### PR TITLE
DatabaseMetaFactory和QueryToolFactory分别获取查询你工具和元信息实例时，通过枚举实现工厂模式

### DIFF
--- a/datax-admin/src/main/java/com/wugui/datax/admin/enums/DatabaseMetaEnum.java
+++ b/datax-admin/src/main/java/com/wugui/datax/admin/enums/DatabaseMetaEnum.java
@@ -1,0 +1,48 @@
+package com.wugui.datax.admin.enums;
+
+import com.wugui.datax.admin.tool.meta.*;
+import com.wugui.datax.admin.util.JdbcConstants;
+
+/**
+ * 数据库meta信息枚举类
+ *
+ * @author Locki
+ * @date 2020/9/10
+ */
+public enum DatabaseMetaEnum {
+    /**
+     * 查询工具
+     */
+    //MYSQL(JdbcConstants.MYSQL, MySQLQueryTool.class),
+    //TODO 目前JdbcConstants常量类中的mysql是小写，但是前端传值为大写
+    MYSQL("MYSQL", MySQLDatabaseMeta.getInstance()),
+    ORACLE(JdbcConstants.ORACLE, OracleDatabaseMeta.getInstance()),
+    POSTGRESQL(JdbcConstants.POSTGRESQL, PostgresqlDatabaseMeta.getInstance()),
+    SPARK(JdbcConstants.GREENPLUM, PostgresqlDatabaseMeta.getInstance()),
+    SQLSERVER(JdbcConstants.SQL_SERVER, SqlServerDatabaseMeta.getInstance()),
+    HIVE(JdbcConstants.HIVE, HiveDatabaseMeta.getInstance()),
+    CLICKHOUSE(JdbcConstants.CLICKHOUSE, ClickHouseDataBaseMeta.getInstance()),
+    HBASE20XSQL(JdbcConstants.HBASE20XSQL, Hbase20xsqlMeta.getInstance()),
+    DB2(JdbcConstants.DB2, null);
+
+    private final String name;
+    private final DatabaseInterface databaseInterface;
+
+    public DatabaseInterface getDatabaseInterface() {
+        return databaseInterface;
+    }
+
+    DatabaseMetaEnum(String name, DatabaseInterface databaseInterface) {
+        this.name = name;
+        this.databaseInterface = databaseInterface;
+    }
+
+    public static DatabaseMetaEnum getQueryToolEnum(String name) {
+        for (DatabaseMetaEnum typeEnum : DatabaseMetaEnum.values()) {
+            if (typeEnum.name.equals(name)) {
+                return typeEnum;
+            }
+        }
+        throw new UnsupportedOperationException("找不到该类型: ".concat(name));
+    }
+}

--- a/datax-admin/src/main/java/com/wugui/datax/admin/enums/QueryToolEnum.java
+++ b/datax-admin/src/main/java/com/wugui/datax/admin/enums/QueryToolEnum.java
@@ -1,0 +1,48 @@
+package com.wugui.datax.admin.enums;
+
+import com.wugui.datax.admin.tool.query.*;
+import com.wugui.datax.admin.util.JdbcConstants;
+
+/**
+ * 数据库类型枚举类
+ *
+ * @author Locki
+ * @date 2020/9/9
+ */
+public enum QueryToolEnum {
+    /**
+     * 查询工具
+     */
+    //MYSQL(JdbcConstants.MYSQL, MySQLQueryTool.class),
+    //TODO 目前JdbcConstants常量类中的mysql是小写，但是前端传值为大写
+    MYSQL("MYSQL", MySQLQueryTool.class),
+    ORACLE(JdbcConstants.ORACLE, OracleQueryTool.class),
+    POSTGRESQL(JdbcConstants.POSTGRESQL, PostgresqlQueryTool.class),
+    SPARK(JdbcConstants.GREENPLUM, PostgresqlQueryTool.class),
+    SQLSERVER(JdbcConstants.SQL_SERVER, SqlServerQueryTool.class),
+    HIVE(JdbcConstants.HIVE, HiveQueryTool.class),
+    CLICKHOUSE(JdbcConstants.CLICKHOUSE, ClickHouseQueryTool.class),
+    HBASE20XSQL(JdbcConstants.HBASE20XSQL, Hbase20XsqlQueryTool.class),
+    DB2(JdbcConstants.DB2, null);
+
+    private final String name;
+    private final Class clazz;
+
+    public Class getClazz() {
+        return clazz;
+    }
+
+    QueryToolEnum(String name, Class clazz) {
+        this.name = name;
+        this.clazz = clazz;
+    }
+
+    public static QueryToolEnum getQueryToolEnum(String name) {
+        for (QueryToolEnum typeEnum : QueryToolEnum.values()) {
+            if (typeEnum.name.equals(name)) {
+                return typeEnum;
+            }
+        }
+        throw new UnsupportedOperationException("找不到该类型: ".concat(name));
+    }
+}

--- a/datax-admin/src/main/java/com/wugui/datax/admin/tool/meta/DatabaseMetaFactory.java
+++ b/datax-admin/src/main/java/com/wugui/datax/admin/tool/meta/DatabaseMetaFactory.java
@@ -1,5 +1,6 @@
 package com.wugui.datax.admin.tool.meta;
 
+import com.wugui.datax.admin.enums.DatabaseMetaEnum;
 import com.wugui.datax.admin.util.JdbcConstants;
 
 /**
@@ -16,24 +17,6 @@ public class DatabaseMetaFactory {
      * @return DatabaseInterface
      */
     public static DatabaseInterface getByDbType(String dbType) {
-        if (JdbcConstants.MYSQL.equals(dbType)) {
-            return MySQLDatabaseMeta.getInstance();
-        } else if (JdbcConstants.ORACLE.equals(dbType)) {
-            return OracleDatabaseMeta.getInstance();
-        } else if (JdbcConstants.POSTGRESQL.equals(dbType)) {
-            return PostgresqlDatabaseMeta.getInstance();
-        } else if (JdbcConstants.GREENPLUM.equals(dbType)) {
-            return PostgresqlDatabaseMeta.getInstance();
-        } else if (JdbcConstants.SQL_SERVER.equals(dbType)) {
-            return SqlServerDatabaseMeta.getInstance();
-        } else if (JdbcConstants.HIVE.equals(dbType)) {
-            return HiveDatabaseMeta.getInstance();
-        } else if (JdbcConstants.CLICKHOUSE.equals(dbType)) {
-            return ClickHouseDataBaseMeta.getInstance();
-        } else if (JdbcConstants.HBASE20XSQL.equals(dbType)) {
-            return Hbase20xsqlMeta.getInstance();
-        } else {
-            throw new UnsupportedOperationException("暂不支持的类型：".concat(dbType));
-        }
+        return DatabaseMetaEnum.getQueryToolEnum(dbType).getDatabaseInterface();
     }
 }

--- a/datax-admin/src/main/java/com/wugui/datax/admin/tool/query/QueryToolFactory.java
+++ b/datax-admin/src/main/java/com/wugui/datax/admin/tool/query/QueryToolFactory.java
@@ -1,10 +1,9 @@
 package com.wugui.datax.admin.tool.query;
 
 import com.wugui.datax.admin.entity.JobDatasource;
-import com.wugui.datax.admin.util.JdbcConstants;
-import com.wugui.datax.admin.util.RdbmsException;
+import com.wugui.datax.admin.enums.QueryToolEnum;
 
-import java.sql.SQLException;
+import java.lang.reflect.Constructor;
 
 /**
  * 工具类，获取单例实体
@@ -19,85 +18,15 @@ public class QueryToolFactory {
     public static BaseQueryTool getByDbType(JobDatasource jobDatasource) {
         //获取dbType
         String datasource = jobDatasource.getDatasource();
-        if (JdbcConstants.MYSQL.equals(datasource)) {
-            return getMySQLQueryToolInstance(jobDatasource);
-        } else if (JdbcConstants.ORACLE.equals(datasource)) {
-            return getOracleQueryToolInstance(jobDatasource);
-        } else if (JdbcConstants.POSTGRESQL.equals(datasource)) {
-            return getPostgresqlQueryToolInstance(jobDatasource);
-        } else if (JdbcConstants.GREENPLUM.equals(datasource)) {
-            return getPostgresqlQueryToolInstance(jobDatasource);
-        } else if (JdbcConstants.SQL_SERVER.equals(datasource)) {
-            return getSqlserverQueryToolInstance(jobDatasource);
-        }else if (JdbcConstants.HIVE.equals(datasource)) {
-            return getHiveQueryToolInstance(jobDatasource);
-        } else if (JdbcConstants.CLICKHOUSE.equals(datasource)) {
-            return getClickHouseQueryToolInstance(jobDatasource);
-        }else if (JdbcConstants.HBASE20XSQL.equals(datasource)) {
-            return getHbase20XsqlQueryToolQueryToolInstance(jobDatasource);
-        }
-        throw new UnsupportedOperationException("找不到该类型: ".concat(datasource));
-    }
-
-    private static BaseQueryTool getMySQLQueryToolInstance(JobDatasource jdbcDatasource) {
+        QueryToolEnum queryToolEnum = QueryToolEnum.getQueryToolEnum(datasource);
         try {
-            return new MySQLQueryTool(jdbcDatasource);
+            Constructor<BaseQueryTool> c = queryToolEnum.getClazz().getConstructor(JobDatasource.class);
+            BaseQueryTool queryTool = c.newInstance(jobDatasource);
+            return queryTool;
         } catch (Exception e) {
-            throw RdbmsException.asConnException(JdbcConstants.MYSQL,
-                    e,jdbcDatasource.getJdbcUsername(),jdbcDatasource.getDatasourceName());
+            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 
-    private static BaseQueryTool getOracleQueryToolInstance(JobDatasource jdbcDatasource) {
-        try {
-            return new OracleQueryTool(jdbcDatasource);
-        } catch (SQLException e) {
-            throw RdbmsException.asConnException(JdbcConstants.ORACLE,
-                    e,jdbcDatasource.getJdbcUsername(),jdbcDatasource.getDatasourceName());
-        }
-    }
-
-    private static BaseQueryTool getPostgresqlQueryToolInstance(JobDatasource jdbcDatasource) {
-        try {
-            return new PostgresqlQueryTool(jdbcDatasource);
-        } catch (SQLException e) {
-            throw RdbmsException.asConnException(JdbcConstants.POSTGRESQL,
-                    e,jdbcDatasource.getJdbcUsername(),jdbcDatasource.getDatasourceName());
-        }
-    }
-
-    private static BaseQueryTool getSqlserverQueryToolInstance(JobDatasource jdbcDatasource) {
-        try {
-            return new SqlServerQueryTool(jdbcDatasource);
-        } catch (SQLException e) {
-            throw RdbmsException.asConnException(JdbcConstants.SQL_SERVER,
-                    e,jdbcDatasource.getJdbcUsername(),jdbcDatasource.getDatasourceName());
-        }
-    }
-
-    private static BaseQueryTool getHiveQueryToolInstance(JobDatasource jdbcDatasource) {
-        try {
-            return new HiveQueryTool(jdbcDatasource);
-        } catch (SQLException e) {
-            throw RdbmsException.asConnException(JdbcConstants.HIVE,
-                    e,jdbcDatasource.getJdbcUsername(),jdbcDatasource.getDatasourceName());
-        }
-    }
-    private static BaseQueryTool getClickHouseQueryToolInstance(JobDatasource jdbcDatasource) {
-        try {
-            return new ClickHouseQueryTool(jdbcDatasource);
-        } catch (SQLException e) {
-            throw RdbmsException.asConnException(JdbcConstants.CLICKHOUSE,
-                    e, jdbcDatasource.getJdbcUsername(), jdbcDatasource.getDatasourceName());
-        }
-    }
-
-    private static Hbase20XsqlQueryTool getHbase20XsqlQueryToolQueryToolInstance(JobDatasource jdbcDatasource) {
-        try {
-            return new Hbase20XsqlQueryTool(jdbcDatasource);
-        } catch (SQLException e) {
-            throw RdbmsException.asConnException(JdbcConstants.HBASE20XSQL,
-                    e, jdbcDatasource.getJdbcUsername(), jdbcDatasource.getDatasourceName());
-        }
-    }
 }


### PR DESCRIPTION
DatabaseMetaFactory和QueryToolFactory分别获取查询你工具和元信息实例时，通过枚举实现工厂模式；

后续需增加数据库支持时，获取DatabaseMeta类和QueryTool时，只需分别在com.wugui.datax.admin.enums.DatabaseMetaEnum和com.wugui.datax.admin.enums.QueryToolEnum中增加枚举值即可；

另外，com.wugui.datax.admin.tool.datax.DataxJsonHelper中的readerPlugin和writerPlugin也可以此方案改造，但由于ClickHouse、Hive、HBase以及MongoDB的构造过程与其他不同，修改面较大，暂未改造