### PR TITLE
JSON构建增加txtfilewriter

### DIFF
--- a/datax-admin/src/main/java/com/wugui/datax/admin/service/impl/DataxJsonServiceImpl.java
+++ b/datax-admin/src/main/java/com/wugui/datax/admin/service/impl/DataxJsonServiceImpl.java
@@ -41,10 +41,12 @@ public class DataxJsonServiceImpl implements DataxJsonService {
         // reader plugin init
         dataxJsonHelper.initReader(dataXJsonBuildDto, readerDatasource);
 
+
         JobDatasource writerDatasource = jobDataSourceService.getById(dataXJsonBuildDto.getWriterDatasourceId());
         //处理writer表名
-        processingTableName(writerDatasource, dataXJsonBuildDto.getWriterTables());
-
+        if(dataXJsonBuildDto.getWriterDatasourceId()>-1) {
+                processingTableName(writerDatasource, dataXJsonBuildDto.getWriterTables());
+         }
         dataxJsonHelper.initWriter(dataXJsonBuildDto, writerDatasource);
 
         return JSON.toJSONString(dataxJsonHelper.buildJob());

--- a/datax-admin/src/main/java/com/wugui/datax/admin/tool/datax/DataxJsonHelper.java
+++ b/datax-admin/src/main/java/com/wugui/datax/admin/tool/datax/DataxJsonHelper.java
@@ -12,6 +12,7 @@ import com.wugui.datax.admin.tool.datax.reader.*;
 import com.wugui.datax.admin.tool.datax.writer.*;
 import com.wugui.datax.admin.tool.pojo.*;
 import com.wugui.datax.admin.util.JdbcConstants;
+import com.wugui.datax.admin.util.StringUtil;
 import com.wugui.datax.admin.util.TransformerUtil;
 import lombok.Data;
 import org.apache.commons.lang3.StringUtils;
@@ -143,6 +144,12 @@ public class DataxJsonHelper implements DataxJsonInterface {
         this.hbaseWriterDto = dataxJsonDto.getHbaseWriter();
         this.mongoDBWriterDto = dataxJsonDto.getMongoDBWriter();
         // writer
+        //数据源id为-1，表示向TXT文件写数据
+        if (dataxJsonDto.getWriterDatasourceId()==-1) {
+            writerPlugin = new TxtFileWriter();
+            buildWriter = this.buildTxtFileWriter();
+            return;
+        }
         String datasource = readerDatasource.getDatasource();
         this.writerColumns = convertKeywordsColumns(datasource, this.writerColumns);
         if (MYSQL.equals(datasource)) {
@@ -312,7 +319,7 @@ public class DataxJsonHelper implements DataxJsonInterface {
         });
         dataxHivePojo.setColumns(columns);
         dataxHivePojo.setReaderDefaultFS(hiveReaderDto.getReaderDefaultFS());
-        dataxHivePojo.setReaderFieldDelimiter(hiveReaderDto.getReaderFieldDelimiter());
+        dataxHivePojo.setReaderFieldDelimiter(StringUtil.unicode2String(hiveReaderDto.getReaderFieldDelimiter()));
         dataxHivePojo.setReaderFileType(hiveReaderDto.getReaderFileType());
         dataxHivePojo.setReaderPath(hiveReaderDto.getReaderPath());
         dataxHivePojo.setSkipHeader(hiveReaderDto.getReaderSkipHeader());
@@ -377,7 +384,7 @@ public class DataxJsonHelper implements DataxJsonInterface {
         });
         dataxHivePojo.setColumns(columns);
         dataxHivePojo.setWriterDefaultFS(hiveWriterDto.getWriterDefaultFS());
-        dataxHivePojo.setWriteFieldDelimiter(hiveWriterDto.getWriteFieldDelimiter());
+        dataxHivePojo.setWriteFieldDelimiter(StringUtil.unicode2String(hiveWriterDto.getWriteFieldDelimiter()));
         dataxHivePojo.setWriterFileType(hiveWriterDto.getWriterFileType());
         dataxHivePojo.setWriterPath(hiveWriterDto.getWriterPath());
         dataxHivePojo.setWriteMode(hiveWriterDto.getWriteMode());
@@ -420,6 +427,17 @@ public class DataxJsonHelper implements DataxJsonInterface {
         dataxMongoDBPojo.setWriterTable(readerTables.get(0));
         dataxMongoDBPojo.setUpsertInfo(mongoDBWriterDto.getUpsertInfo());
         return writerPlugin.buildMongoDB(dataxMongoDBPojo);
+    }
+
+    @Override
+    public Map<String, Object> buildTxtFileWriter() {
+        DataxHivePojo dataxHivePojo = new DataxHivePojo();//txtfile传参实体与hive通用
+        dataxHivePojo.setWriterPath(hiveWriterDto.getWriterPath());
+        dataxHivePojo.setWriterFileName(hiveWriterDto.getWriterFileName());
+        dataxHivePojo.setWriteMode(hiveWriterDto.getWriteMode());
+        dataxHivePojo.setWriteFieldDelimiter(StringUtil.unicode2String(hiveWriterDto.getWriteFieldDelimiter()));
+        dataxHivePojo.setWriterFileType(hiveWriterDto.getWriterFileType());
+        return writerPlugin.buildTxtFile(dataxHivePojo);
     }
 
     private void buildColumns(List<String> columns, List<Map<String, Object>> returnColumns) {

--- a/datax-admin/src/main/java/com/wugui/datax/admin/tool/datax/DataxJsonInterface.java
+++ b/datax-admin/src/main/java/com/wugui/datax/admin/tool/datax/DataxJsonInterface.java
@@ -83,6 +83,13 @@ public interface DataxJsonInterface {
     Map<String, Object> buildMongoDBWriter();
 
     /**
+     * buildTxtFileWriter
+     *
+     * @return
+     */
+    Map<String, Object> buildTxtFileWriter();
+
+    /**
      * buildWriter
      *
      * @return

--- a/datax-admin/src/main/java/com/wugui/datax/admin/tool/datax/DataxPluginInterface.java
+++ b/datax-admin/src/main/java/com/wugui/datax/admin/tool/datax/DataxPluginInterface.java
@@ -56,6 +56,14 @@ public interface DataxPluginInterface {
     Map<String, Object> buildMongoDB(DataxMongoDBPojo dataxMongoDBPojo);
 
     /**
+     * txtfile json构建
+     *
+     * @param dataxHivePojo
+     * @return
+     */
+    Map<String,Object> buildTxtFile(DataxHivePojo dataxHivePojo);
+
+    /**
      * 获取示例
      *
      * @return

--- a/datax-admin/src/main/java/com/wugui/datax/admin/tool/datax/reader/BaseReaderPlugin.java
+++ b/datax-admin/src/main/java/com/wugui/datax/admin/tool/datax/reader/BaseReaderPlugin.java
@@ -69,4 +69,9 @@ public abstract class BaseReaderPlugin extends BaseDataxPlugin {
     public Map<String, Object> buildMongoDB(DataxMongoDBPojo dataxMongoDBPojo) {
         return null;
     }
+
+    @Override
+    public Map<String, Object> buildTxtFile(DataxHivePojo dataxHivePojo) {
+        return null;
+    }
 }

--- a/datax-admin/src/main/java/com/wugui/datax/admin/tool/datax/writer/BaseWriterPlugin.java
+++ b/datax-admin/src/main/java/com/wugui/datax/admin/tool/datax/writer/BaseWriterPlugin.java
@@ -79,4 +79,9 @@ public abstract class BaseWriterPlugin extends BaseDataxPlugin {
     public Map<String, Object> buildMongoDB(DataxMongoDBPojo plugin) {
         return null;
     }
+
+    @Override
+    public Map<String, Object> buildTxtFile(DataxHivePojo dataxHivePojo) {
+        return null;
+    }
 }

--- a/datax-admin/src/main/java/com/wugui/datax/admin/tool/datax/writer/TxtFileWriter.java
+++ b/datax-admin/src/main/java/com/wugui/datax/admin/tool/datax/writer/TxtFileWriter.java
@@ -1,0 +1,43 @@
+package com.wugui.datax.admin.tool.datax.writer;
+
+import com.google.common.collect.Maps;
+import com.wugui.datax.admin.tool.pojo.DataxHivePojo;
+
+import java.util.Map;
+
+/**
+ * txtfile writer构建类
+ *
+ * @author liu.siqi
+ * @Version 1.0
+ * @since 2020/7/11
+ */
+public class TxtFileWriter extends BaseWriterPlugin implements DataxWriterInterface {
+    @Override
+    public String getName() {
+        return "txtfilewriter";
+    }
+
+    @Override
+    public Map<String, Object> sample() {
+        return null;
+    }
+
+    @Override
+    public Map<String, Object> buildTxtFile(DataxHivePojo plugin) {
+
+        Map<String, Object> writerObj = Maps.newLinkedHashMap();
+        writerObj.put("name", getName());
+        Map<String, Object> parameterObj = Maps.newLinkedHashMap();
+        parameterObj.put("path", plugin.getWriterPath());
+        parameterObj.put("fileName", plugin.getWriterFileName());
+        parameterObj.put("writeMode", plugin.getWriteMode());
+        parameterObj.put("fieldDelimiter", plugin.getWriteFieldDelimiter());
+        parameterObj.put("dateFormat", "yyyy-MM-dd");
+        parameterObj.put("fileFormat", plugin.getWriterFileType());
+        writerObj.put("parameter", parameterObj);
+        System.out.println("writerObj"+writerObj);
+        return writerObj;
+    }
+
+}

--- a/datax-admin/src/main/java/com/wugui/datax/admin/util/StringUtil.java
+++ b/datax-admin/src/main/java/com/wugui/datax/admin/util/StringUtil.java
@@ -1,0 +1,96 @@
+package com.wugui.datax.admin.util;
+
+import org.apache.commons.lang.StringEscapeUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ *字符串处理工具类
+ */
+public class StringUtil {
+
+    private static Logger logger = LoggerFactory.getLogger(StringUtil.class);
+
+    /**
+     * 查询字符串ddl中 以tag开始第一个'与第二个'之间的内容
+     * @param ddl
+     * @param tag
+     * @return
+     */
+    public static String find(String ddl,String tag){
+        String result = "";
+        String str = ddl.substring(ddl.indexOf(tag) + tag.length()).trim();
+        result = str.substring(getCharacterPosition(str,"'",1) + 1,getCharacterPosition(str,"'",2));
+        return result;
+    }
+
+    /**
+     * 查询字符串在字符串中第N次出现的位置
+     * @param string
+     * @param tag
+     * @param time
+     * @return
+     */
+    public static int getCharacterPosition(String string, String tag, int time){
+        Matcher slashMatcher = Pattern.compile(tag).matcher(string);
+        int mIdx = 0;
+        while(slashMatcher.find()) {
+            mIdx++;
+            if(mIdx == time){
+                break;
+            }
+        }
+        return slashMatcher.start();
+    }
+
+    /**
+     * 字符串转换unicode
+     * @param string
+     * @return
+     */
+    public static String string2Unicode(String string) {
+        StringBuffer unicode = new StringBuffer();
+        for (int i = 0; i < string.length(); i++) {
+            // 取出每一个字符
+            char c = string.charAt(i);
+            // 转换为unicode
+            unicode.append("\\u" + Integer.toHexString(c));
+        }
+        return unicode.toString();
+    }
+
+    /**
+     * unicode 转字符串
+     * @param unicode 全为 Unicode 的字符串
+     * @return
+     */
+    public static String unicode2String(String unicode) {
+        try{
+            unicode = (unicode == null ? "" : unicode);
+            if (unicode.indexOf("\\") == -1)//如果不是unicode码则原样返回
+                return unicode;
+            // 该步骤可以处理掉\\t \\n \\u0001等类似字符串
+            String resulr = StringEscapeUtils.unescapeJava(unicode);
+            if(resulr.length() == 1){
+                return resulr;
+            }else{
+                // 该处处理的是 \\001  等类似字符串
+                StringBuffer string = new StringBuffer();
+                String[] hex = unicode.split("\\\\");
+                for (int i = 1; i < hex.length; i++) {
+                    // 转换出每一个代码点
+                    int data = Integer.parseInt(hex[i], 16);
+                    // 追加成string
+                    string.append((char) data);
+                }
+                return string.toString();
+            }
+        }catch (Exception e){
+            logger.error(e.getMessage());
+            return unicode;
+        }
+    }
+}


### PR DESCRIPTION
出于同步外部表需求，任务构建中添加了对txtfilewriter的支持
1.不需建立数据源，在任务构建writer数据源下拉项中选则'TXT文件'，writerDatasourceId默认-1，后端据此判定writer类型为txtfile，任务执行后数据文件保存在datax执行器主机对应路径下。
2.由于json参数配置项与hdfs大体兼容，未定义新的参数传递实体，直接使用了HiveWriterDTO与DataxHivePojo