### PR TITLE
V2.1.2 非datax和脚本任务，无法正常手工终止的问题修复

### DIFF
--- a/datax-admin/src/main/java/com/wugui/datax/admin/controller/JobLogController.java
+++ b/datax-admin/src/main/java/com/wugui/datax/admin/controller/JobLogController.java
@@ -3,6 +3,7 @@ package com.wugui.datax.admin.controller;
 import com.wugui.datatx.core.biz.ExecutorBiz;
 import com.wugui.datatx.core.biz.model.LogResult;
 import com.wugui.datatx.core.biz.model.ReturnT;
+import com.wugui.datatx.core.glue.GlueTypeEnum;
 import com.wugui.datatx.core.util.DateUtil;
 import com.wugui.datax.admin.core.kill.KillJob;
 import com.wugui.datax.admin.core.scheduler.JobScheduler;
@@ -94,7 +95,7 @@ public class JobLogController {
 
     @RequestMapping(value = "/logKill", method = RequestMethod.POST)
     @ApiOperation("kill任务")
-    public ReturnT<String> logKill(int id) {
+    public ReturnT<String> logKill(long id) {
         // base check
         JobLog log = jobLogMapper.load(id);
         JobInfo jobInfo = jobInfoMapper.loadById(log.getJobId());
@@ -168,6 +169,11 @@ public class JobLogController {
     @ApiOperation("停止该job作业")
     @PostMapping("/killJob")
     public ReturnT<String> killJob(@RequestBody JobLog log) {
-        return KillJob.trigger(log.getId(), log.getTriggerTime(), log.getExecutorAddress(), log.getProcessId());
+        JobInfo jobInfo = jobInfoMapper.loadById(log.getJobId());
+        if (GlueTypeEnum.match(jobInfo.getGlueType()) == GlueTypeEnum.DATAX) {
+            return KillJob.trigger(log.getId(), log.getTriggerTime(), log.getExecutorAddress(), log.getProcessId());
+        } else {
+            return this.logKill(log.getId());
+        }
     }
 }

--- a/datax-admin/src/main/java/com/wugui/datax/admin/controller/JobLogController.java
+++ b/datax-admin/src/main/java/com/wugui/datax/admin/controller/JobLogController.java
@@ -170,7 +170,7 @@ public class JobLogController {
     @PostMapping("/killJob")
     public ReturnT<String> killJob(@RequestBody JobLog log) {
         JobInfo jobInfo = jobInfoMapper.loadById(log.getJobId());
-        if (GlueTypeEnum.match(jobInfo.getGlueType()) == GlueTypeEnum.DATAX) {
+        if (GlueTypeEnum.match(jobInfo.getGlueType()) == GlueTypeEnum.DATAX || GlueTypeEnum.match(jobInfo.getGlueType()).isScript()) {
             return KillJob.trigger(log.getId(), log.getTriggerTime(), log.getExecutorAddress(), log.getProcessId());
         } else {
             return this.logKill(log.getId());


### PR DESCRIPTION
非datax和脚本任务，无法正常手工终止的问题修复

前一个PR #330 未考虑到脚本任务已经获取保存了ProcessId，可以通过kill pid的方式中止任务；
java任务仍需要Thread.interrupt()