### PR TITLE
增加SDK，以支持应用直接调用api维护任务；目前仅支持JAVA任务

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@
 /build/
 /packages/
 /datax-assembly/target/
+datax-web-sdk/target/*
+datax-web-sdk-spring-boot-starter/target/*

--- a/datax-admin/pom.xml
+++ b/datax-admin/pom.xml
@@ -26,7 +26,11 @@
     </dependencyManagement>
 
     <dependencies>
-
+        <dependency>
+            <groupId>com.wugui</groupId>
+            <artifactId>datax-web-sdk</artifactId>
+            <version>2.1.2</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
@@ -793,6 +797,11 @@
             <groupId>com.ibm.db2.jcc</groupId>
             <artifactId>db2jcc</artifactId>
             <version>db2jcc4</version>
+        </dependency>
+        <dependency>
+            <groupId>cn.hutool</groupId>
+            <artifactId>hutool-all</artifactId>
+            <version>${hutool.version}</version>
         </dependency>
     </dependencies>
 

--- a/datax-admin/src/main/java/com/wugui/datax/admin/config/SecurityConfig.java
+++ b/datax-admin/src/main/java/com/wugui/datax/admin/config/SecurityConfig.java
@@ -2,8 +2,10 @@ package com.wugui.datax.admin.config;
 
 
 import com.wugui.datatx.core.util.Constants;
+import com.wugui.datax.admin.filter.ApiAuthorizationFilter;
 import com.wugui.datax.admin.filter.JWTAuthenticationFilter;
 import com.wugui.datax.admin.filter.JWTAuthorizationFilter;
+import com.wugui.datax.admin.mapper.JobUserMapper;
 import com.wugui.datax.admin.service.impl.UserDetailsServiceImpl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -28,6 +30,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Autowired
     private UserDetailsService userDetailsService;
+    @Autowired
+    private JobUserMapper jobUserMapper;
 
     @Bean
     UserDetailsService customUserService(){ //注册UserDetailsService 的bean
@@ -57,6 +61,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .and()
                 .addFilter(new JWTAuthenticationFilter(authenticationManager()))
                 .addFilter(new JWTAuthorizationFilter(authenticationManager()))
+                .addFilter(new ApiAuthorizationFilter(authenticationManager(), jobUserMapper))
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
     }
 

--- a/datax-admin/src/main/java/com/wugui/datax/admin/controller/JobInfoController.java
+++ b/datax-admin/src/main/java/com/wugui/datax/admin/controller/JobInfoController.java
@@ -85,6 +85,12 @@ public class JobInfoController extends BaseController{
         return jobService.start(id);
     }
 
+    @RequestMapping(value = "/loadJob", method = RequestMethod.POST)
+    @ApiOperation("查询任务详情")
+    public JobInfo loadJob(int id) {
+        return jobService.loadJob(id);
+    }
+
     @PostMapping(value = "/trigger")
     @ApiOperation("触发任务")
     public ReturnT<String> triggerJob(@RequestBody TriggerJobDto dto) {

--- a/datax-admin/src/main/java/com/wugui/datax/admin/controller/JobLogController.java
+++ b/datax-admin/src/main/java/com/wugui/datax/admin/controller/JobLogController.java
@@ -41,7 +41,7 @@ public class JobLogController {
     @GetMapping("/pageList")
     @ApiOperation("运行日志列表")
     public ReturnT<Map<String, Object>> pageList(
-            @RequestParam(required = false, defaultValue = "0") int current,
+            @RequestParam(required = false, defaultValue = "1") int current,
             @RequestParam(required = false, defaultValue = "10") int size,
             int jobGroup, int jobId, int logStatus, String filterTime) {
 

--- a/datax-admin/src/main/java/com/wugui/datax/admin/controller/UserController.java
+++ b/datax-admin/src/main/java/com/wugui/datax/admin/controller/UserController.java
@@ -5,6 +5,7 @@ import com.wugui.datatx.core.biz.model.ReturnT;
 import com.wugui.datax.admin.core.util.I18nUtil;
 import com.wugui.datax.admin.entity.JobUser;
 import com.wugui.datax.admin.mapper.JobUserMapper;
+import com.wugui.datax.client.util.AppUtil;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -119,6 +120,17 @@ public class UserController {
         // write
         jobUserMapper.update(jobUser);
         return ReturnT.SUCCESS;
+    }
+
+    @PostMapping(value = "/updateKey")
+    @ApiOperation("更新用户AccessKey/SecretKey")
+    public ReturnT<JobUser> updateKey(@RequestBody JobUser jobUser) {
+        String accesskey = AppUtil.getAccessKey();
+        String secretkey = AppUtil.getSecretKey(jobUser.getUsername(), accesskey);
+        jobUser.setAccessKey(accesskey);
+        jobUser.setSecretKey(secretkey);
+        this.jobUserMapper.updateKey(jobUser);
+        return new ReturnT<>(jobUser);
     }
 
     @RequestMapping(value = "/remove", method = RequestMethod.POST)

--- a/datax-admin/src/main/java/com/wugui/datax/admin/entity/JobInfo.java
+++ b/datax-admin/src/main/java/com/wugui/datax/admin/entity/JobInfo.java
@@ -1,6 +1,7 @@
 package com.wugui.datax.admin.entity;
 
 import com.baomidou.mybatisplus.annotation.TableField;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 
@@ -14,112 +15,113 @@ import java.util.Date;
 @Data
 public class JobInfo {
 
-	@ApiModelProperty("主键ID")
-	private int id;
+    @ApiModelProperty("主键ID")
+    private int id;
 
-	@ApiModelProperty("执行器主键ID")
-	private int jobGroup;
+    @ApiModelProperty("执行器主键ID")
+    private int jobGroup;
 
-	@ApiModelProperty("任务执行CRON表达式")
-	private String jobCron;
+    @ApiModelProperty("任务执行CRON表达式")
+    private String jobCron;
 
-	@ApiModelProperty("排序")
-	private String jobDesc;
+    @ApiModelProperty("排序")
+    private String jobDesc;
 
-	private Date addTime;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "GMT+8")
+    private Date addTime;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "GMT+8")
+    private Date updateTime;
 
-	private Date updateTime;
+    @ApiModelProperty("修改用户")
+    private int userId;
 
-	@ApiModelProperty("修改用户")
-	private int userId;
+    @ApiModelProperty("报警邮件")
+    private String alarmEmail;
 
-	@ApiModelProperty("报警邮件")
-	private String alarmEmail;
+    @ApiModelProperty("执行器路由策略")
+    private String executorRouteStrategy;
 
-	@ApiModelProperty("执行器路由策略")
-	private String executorRouteStrategy;
+    @ApiModelProperty("执行器，任务Handler名称")
+    private String executorHandler;
 
-	@ApiModelProperty("执行器，任务Handler名称")
-	private String executorHandler;
+    @ApiModelProperty("执行器，任务参数")
+    private String executorParam;
 
-	@ApiModelProperty("执行器，任务参数")
-	private String executorParam;
+    @ApiModelProperty("阻塞处理策略")
+    private String executorBlockStrategy;
 
-	@ApiModelProperty("阻塞处理策略")
-	private String executorBlockStrategy;
+    @ApiModelProperty("任务执行超时时间，单位秒")
+    private int executorTimeout;
 
-	@ApiModelProperty("任务执行超时时间，单位秒")
-	private int executorTimeout;
+    @ApiModelProperty("失败重试次数")
+    private int executorFailRetryCount;
 
-	@ApiModelProperty("失败重试次数")
-	private int executorFailRetryCount;
+    @ApiModelProperty("GLUE类型\t#com.wugui.datatx.core.glue.GlueTypeEnum")
+    private String glueType;
 
-	@ApiModelProperty("GLUE类型\t#com.wugui.datatx.core.glue.GlueTypeEnum")
-	private String glueType;
+    @ApiModelProperty("GLUE源代码")
+    private String glueSource;
 
-	@ApiModelProperty("GLUE源代码")
-	private String glueSource;
+    @ApiModelProperty("GLUE备注")
+    private String glueRemark;
 
-	@ApiModelProperty("GLUE备注")
-	private String glueRemark;
+    @ApiModelProperty("GLUE更新时间")
+    private Date glueUpdatetime;
 
-	@ApiModelProperty("GLUE更新时间")
-	private Date glueUpdatetime;
+    @ApiModelProperty("子任务ID")
+    private String childJobId;
 
-	@ApiModelProperty("子任务ID")
-	private String childJobId;
+    @ApiModelProperty("调度状态：0-停止，1-运行")
+    private int triggerStatus;
 
-	@ApiModelProperty("调度状态：0-停止，1-运行")
-	private int triggerStatus;
+    @ApiModelProperty("上次调度时间")
+    private long triggerLastTime;
 
-	@ApiModelProperty("上次调度时间")
-	private long triggerLastTime;
+    @ApiModelProperty("下次调度时间")
+    private long triggerNextTime;
 
-	@ApiModelProperty("下次调度时间")
-	private long triggerNextTime;
+    @ApiModelProperty("datax运行json")
+    private String jobJson;
 
-	@ApiModelProperty("datax运行json")
-	private String jobJson;
+    @ApiModelProperty("脚本动态参数")
+    private String replaceParam;
 
-	@ApiModelProperty("脚本动态参数")
-	private String replaceParam;
+    @ApiModelProperty("增量日期格式")
+    private String replaceParamType;
 
-	@ApiModelProperty("增量日期格式")
-	private String replaceParamType;
+    @ApiModelProperty("jvm参数")
+    private String jvmParam;
 
-	@ApiModelProperty("jvm参数")
-	private String jvmParam;
+    @ApiModelProperty("增量初始时间")
+    private Date incStartTime;
 
-	@ApiModelProperty("增量初始时间")
-	private Date incStartTime;
+    @ApiModelProperty("分区信息")
+    private String partitionInfo;
 
-	@ApiModelProperty("分区信息")
-	private String partitionInfo;
+    @ApiModelProperty("最近一次执行状态")
+    private int lastHandleCode;
 
-	@ApiModelProperty("最近一次执行状态")
-	private int lastHandleCode;
+    @ApiModelProperty("所属项目Id")
+    private int projectId;
 
-	@ApiModelProperty("所属项目Id")
-	private int projectId;
+    @ApiModelProperty("主键字段")
+    private String primaryKey;
 
-	@ApiModelProperty("主键字段")
-	private String primaryKey;
+    @ApiModelProperty("增量初始id")
+    private Long incStartId;
 
-	@ApiModelProperty("增量初始id")
-	private Long incStartId;
+    @ApiModelProperty("增量方式")
+    private int incrementType;
 
-	@ApiModelProperty("增量方式")
-	private int incrementType;
+    @ApiModelProperty("datax的读表")
+    private String readerTable;
 
-	@ApiModelProperty("datax的读表")
-	private  String readerTable;
+    @ApiModelProperty("数据源id")
+    private int datasourceId;
 
-	@ApiModelProperty("数据源id")
-	private int datasourceId;
+    @TableField(exist = false)
+    private String projectName;
 
-	@TableField(exist=false)
-	private String projectName;
-
-	@TableField(exist=false)
-	private String userName;
+    @TableField(exist = false)
+    private String userName;
 }

--- a/datax-admin/src/main/java/com/wugui/datax/admin/entity/JobUser.java
+++ b/datax-admin/src/main/java/com/wugui/datax/admin/entity/JobUser.java
@@ -17,6 +17,10 @@ public class JobUser {
     private String role;
     @ApiModelProperty("权限：执行器ID列表，多个逗号分割")
     private String permission;
+    @ApiModelProperty("应用SDK接入：接入标识")
+    private String accessKey;
+    @ApiModelProperty("应用SDK接入：接入密钥")
+    private String secretKey;
 
     public int getId() {
         return id;
@@ -58,8 +62,24 @@ public class JobUser {
         this.permission = permission;
     }
 
+    public String getAccessKey() {
+        return accessKey;
+    }
+
+    public void setAccessKey(String accessKey) {
+        this.accessKey = accessKey;
+    }
+
+    public String getSecretKey() {
+        return secretKey;
+    }
+
+    public void setSecretKey(String secretKey) {
+        this.secretKey = secretKey;
+    }
+
     // plugin
-    public boolean validPermission(int jobGroup){
+    public boolean validPermission(int jobGroup) {
         if ("1".equals(this.role)) {
             return true;
         } else {

--- a/datax-admin/src/main/java/com/wugui/datax/admin/filter/ApiAuthorizationFilter.java
+++ b/datax-admin/src/main/java/com/wugui/datax/admin/filter/ApiAuthorizationFilter.java
@@ -1,0 +1,120 @@
+package com.wugui.datax.admin.filter;
+
+import cn.hutool.core.date.DateField;
+import cn.hutool.core.date.DateUtil;
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.TypeReference;
+import com.baomidou.mybatisplus.extension.api.R;
+import com.wugui.datax.admin.entity.JobUser;
+import com.wugui.datax.admin.exception.TokenIsExpiredException;
+import com.wugui.datax.admin.mapper.JobUserMapper;
+import com.wugui.datax.admin.util.JwtTokenUtils;
+import com.wugui.datax.admin.wrapper.RequestWrapper;
+import com.wugui.datax.client.util.AppUtil;
+import org.apache.commons.lang.StringUtils;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * 第三方应用API接入鉴权
+ *
+ * @author Locki
+ * @date 2020/9/28
+ */
+public class ApiAuthorizationFilter extends BasicAuthenticationFilter {
+
+    private JobUserMapper jobUserMapper;
+
+    public ApiAuthorizationFilter(AuthenticationManager authenticationManager, JobUserMapper jobUserMapper) {
+        super(authenticationManager);
+        this.jobUserMapper = jobUserMapper;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain chain) throws IOException, ServletException {
+        RequestWrapper requestWrapper = new RequestWrapper(request);
+        //优先取request body参数
+        Map<String, String> map = JSON.parseObject(requestWrapper.getBodyString(), new TypeReference<Map<String, String>>() {
+        });
+        if (map == null) {
+            map = new HashMap<>();
+            //request body无参数才getParameter
+            Enumeration<String> enums = requestWrapper.getParameterNames();
+            while (enums.hasMoreElements()) {
+                String key = enums.nextElement();
+                map.put(key, requestWrapper.getParameter(key));
+            }
+        }
+        if (map == null || map.isEmpty()) {
+            chain.doFilter(requestWrapper, response);
+            return;
+        }
+        String accessKey = map.get("accessKey");
+        String sign = map.get("sign");
+        String timestamp = map.get("timestamp");
+        if (StringUtils.isBlank(accessKey) || StringUtils.isBlank(sign) || StringUtils.isBlank(timestamp)) {
+            //没有应用接入标识则直接放行
+            chain.doFilter(requestWrapper, response);
+            return;
+        }
+        long time = Long.parseLong(timestamp);
+        if (!DateUtil.isExpired(new Date(time), DateField.MINUTE, 15, new Date())) {
+            //有效期已过则直接放行
+            chain.doFilter(requestWrapper, response);
+            return;
+        }
+
+        JobUser jobUser = jobUserMapper.getUserByAccesskey(accessKey);
+        if (jobUser == null) {
+            //应用接入标识无效则直接放行
+            chain.doFilter(requestWrapper, response);
+            return;
+        }
+        String checkSign = AppUtil.sign(map, jobUser.getSecretKey());
+        if (!sign.equals(checkSign)) {
+            //签名验证不通过则直接放行
+            chain.doFilter(requestWrapper, response);
+            return;
+        }
+
+        // 如果请求头中有token，则进行解析，并且设置认证信息
+        try {
+            SecurityContextHolder.getContext().setAuthentication(getAuthentication(jobUser, requestWrapper));
+        } catch (TokenIsExpiredException e) {
+            //返回json形式的错误信息
+            response.setCharacterEncoding("UTF-8");
+            response.setContentType("application/json; charset=utf-8");
+            response.getWriter().write(JSON.toJSONString(R.failed(e.getMessage())));
+            response.getWriter().flush();
+            return;
+        }
+        super.doFilterInternal(requestWrapper, response, chain);
+    }
+
+    // 获取用户信息并新建一个token
+    private UsernamePasswordAuthenticationToken getAuthentication(JobUser jobUser, RequestWrapper request) throws TokenIsExpiredException {
+        String token = JwtTokenUtils.createToken(jobUser.getId(),jobUser.getUsername(), jobUser.getRole(), false);
+        request.putHeader("Authorization", JwtTokenUtils.TOKEN_PREFIX + token);
+        return new UsernamePasswordAuthenticationToken(jobUser.getUsername(), null,
+                Collections.singleton(new SimpleGrantedAuthority(jobUser.getRole())));
+    }
+
+    public static void main(String[] args) {
+        String s = "{\"alarmEmail\":\"1\",\"executorParam\":\"{\\\"type\\\":\\\" DB2\\\",\\\"url\\\":\\\"jdbc:db2://10.0.0.65:50000/DATANALY\\\",\\\"user\\\":\\\"db2admin\\\",\\\"code\\\":\\\"db2admin\\\",\\\"pros\\\":[\\\"PD_ZM_K_RLIC_D\\\",\\\"PD_ZM_K_CASEINFO_D(5)\\\"]}\",\"jobJson\":\"{\\\"type\\\":\\\" DB2\\\",\\\"url\\\":\\\"jdbc:db2://10.0.0.65:50000/DATANALY\\\",\\\"user\\\":\\\"db2admin\\\",\\\"code\\\":\\\"db2admin\\\",\\\"pros\\\":[\\\"PD_ZM_K_RLIC_D\\\",\\\"PD_ZM_K_CASEINFO_D(5)\\\"]}\",\"executorBlockStrategy\":\"SERIAL_EXECUTION\",\"author\":\"蒋洋\",\"executorRouteStrategy\":\"FIRST\",\"jobCron\":\"0 0 12 * * ? *\",\"sign\":\"8FEA9EA8FD200F94CF2596AEB071B608\",\"jobGroup\":\"1\",\"jobDesc\":\"system测试任务\",\"userId\":\"1\",\"accessKey\":\"vCTez6oi\",\"glueType\":\"JAVA_BEAN\",\"executorHandler\":\"procedureHandler\",\"executorFailRetryCount\":\"0\",\"executorTimeout\":\"0\",\"projectId\":null,\"timestamp\":\"1602745949221\"}";
+        System.out.println(s);
+        Map<String, String> map = JSON.parseObject(s, new TypeReference<Map<String, String>>(){});
+        map.forEach((k, v) -> System.out.println("key=" + k + ";value=" + v));
+    }
+}

--- a/datax-admin/src/main/java/com/wugui/datax/admin/mapper/JobUserMapper.java
+++ b/datax-admin/src/main/java/com/wugui/datax/admin/mapper/JobUserMapper.java
@@ -28,11 +28,15 @@ public interface JobUserMapper {
 
     JobUser getUserById(@Param("id") int id);
 
+    JobUser getUserByAccesskey(@Param("accesskey") String accesskey);
+
     List<JobUser> getUsersByIds(@Param("ids") String[] ids);
 
     int save(JobUser jobUser);
 
     int update(JobUser jobUser);
+
+    int updateKey(JobUser jobUser);
 
     int delete(@Param("id") int id);
 

--- a/datax-admin/src/main/java/com/wugui/datax/admin/service/JobService.java
+++ b/datax-admin/src/main/java/com/wugui/datax/admin/service/JobService.java
@@ -28,7 +28,7 @@ public interface JobService {
      * @param userId
      * @return
      */
-    Map<String, Object> pageList(int start, int length, int jobGroup, int triggerStatus, String jobDesc, String glueType, int userId,Integer[] projectIds);
+    Map<String, Object> pageList(int start, int length, int jobGroup, int triggerStatus, String jobDesc, String glueType, int userId, Integer[] projectIds);
 
     List<JobInfo> list();
 
@@ -89,8 +89,19 @@ public interface JobService {
 
     /**
      * batch add
+     *
      * @param dto
      * @return
      */
     ReturnT<String> batchAdd(DataXBatchJsonBuildDto dto) throws IOException;
+
+    /**
+     * get job
+     *
+     * @param id
+     * @return {@link JobInfo}
+     * @author jiangyang
+     * @date 2020/10/15
+     */
+    JobInfo loadJob(int id);
 }

--- a/datax-admin/src/main/java/com/wugui/datax/admin/service/impl/JobServiceImpl.java
+++ b/datax-admin/src/main/java/com/wugui/datax/admin/service/impl/JobServiceImpl.java
@@ -462,4 +462,9 @@ public class JobServiceImpl implements JobService {
         }
         return ReturnT.SUCCESS;
     }
+
+    @Override
+    public JobInfo loadJob(int id) {
+        return jobInfoMapper.loadById(id);
+    }
 }

--- a/datax-admin/src/main/java/com/wugui/datax/admin/wrapper/RequestWrapper.java
+++ b/datax-admin/src/main/java/com/wugui/datax/admin/wrapper/RequestWrapper.java
@@ -1,0 +1,164 @@
+package com.wugui.datax.admin.wrapper;
+
+import lombok.extern.slf4j.Slf4j;
+
+import javax.servlet.ReadListener;
+import javax.servlet.ServletInputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import java.io.*;
+import java.nio.charset.Charset;
+import java.util.*;
+
+/**
+ * 包装HttpServletRequest，目的是让其输入流可重复读
+ *
+ * @author Locki
+ * @date 2020/10/15
+ */
+@Slf4j
+public class RequestWrapper extends HttpServletRequestWrapper {
+    /**
+     * 自定义请求头
+     */
+    private final Map<String, String> customHeaders;
+
+    /**
+     * 存储body数据的容器
+     */
+    private final byte[] body;
+
+    public RequestWrapper(HttpServletRequest request) throws IOException {
+        super(request);
+        // 将body数据存储起来
+        String bodyStr = getBodyString(request);
+        body = bodyStr.getBytes(Charset.defaultCharset());
+        //初始化请求头map
+        this.customHeaders = new HashMap<>();
+    }
+
+    /**
+     * 设置请求头
+     *
+     * @param name
+     * @param value
+     * @return
+     * @author jiangyang
+     * @date 2020/10/15
+     */
+    public void putHeader(String name, String value) {
+        this.customHeaders.put(name, value);
+    }
+
+    @Override
+    public String getHeader(String name) {
+        // check the custom headers first
+        String headerValue = customHeaders.get(name);
+
+        if (headerValue != null) {
+            return headerValue;
+        }
+        // else return from into the original wrapped object
+        return ((HttpServletRequest) getRequest()).getHeader(name);
+    }
+
+    @Override
+    public Enumeration<String> getHeaders(String name) {
+        List<String> values = Collections.list(super.getHeaders(name));
+        if (this.customHeaders.containsKey(name)) {
+            values.add(this.customHeaders.get(name));
+        }
+        return Collections.enumeration(values);
+    }
+
+    /**
+     * 获取请求Body
+     *
+     * @param request request
+     * @return String
+     */
+    public String getBodyString(final ServletRequest request) {
+        try {
+            return inputStream2String(request.getInputStream());
+        } catch (IOException e) {
+            log.error("", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * 获取请求Body
+     *
+     * @return String
+     */
+    public String getBodyString() {
+        final InputStream inputStream = new ByteArrayInputStream(body);
+
+        return inputStream2String(inputStream);
+    }
+
+    /**
+     * 将inputStream里的数据读取出来并转换成字符串
+     *
+     * @param inputStream inputStream
+     * @return String
+     */
+    private String inputStream2String(InputStream inputStream) {
+        StringBuilder sb = new StringBuilder();
+        BufferedReader reader = null;
+
+        try {
+            reader = new BufferedReader(new InputStreamReader(inputStream, Charset.defaultCharset()));
+            String line;
+            while ((line = reader.readLine()) != null) {
+                sb.append(line);
+            }
+        } catch (IOException e) {
+            log.error("", e);
+            throw new RuntimeException(e);
+        } finally {
+            if (reader != null) {
+                try {
+                    reader.close();
+                } catch (IOException e) {
+                    log.error("", e);
+                }
+            }
+        }
+
+        return sb.toString();
+    }
+
+    @Override
+    public BufferedReader getReader() throws IOException {
+        return new BufferedReader(new InputStreamReader(getInputStream()));
+    }
+
+    @Override
+    public ServletInputStream getInputStream() throws IOException {
+
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream(body);
+
+        return new ServletInputStream() {
+            @Override
+            public int read() throws IOException {
+                return inputStream.read();
+            }
+
+            @Override
+            public boolean isFinished() {
+                return false;
+            }
+
+            @Override
+            public boolean isReady() {
+                return false;
+            }
+
+            @Override
+            public void setReadListener(ReadListener readListener) {
+            }
+        };
+    }
+}

--- a/datax-admin/src/main/resources/mybatis-mapper/JobUserMapper.xml
+++ b/datax-admin/src/main/resources/mybatis-mapper/JobUserMapper.xml
@@ -9,6 +9,8 @@
         <result column="password" property="password"/>
         <result column="role" property="role" />
         <result column="permission" property="permission" />
+        <result column="accesskey" property="accessKey" />
+        <result column="secretkey" property="secretKey" />
     </resultMap>
 
     <sql id="Base_Column_List">
@@ -16,14 +18,18 @@
 		t.username,
 		t.password,
 		t.role,
-		t.permission
+		t.permission,
+		t.accesskey,
+		t.secretkey
 	</sql>
 
     <sql id="Show_Column_List">
 		t.id,
 		t.username,
 		t.role,
-		t.permission
+		t.permission,
+		t.accesskey,
+		t.secretkey
 	</sql>
 
     <select id="pageList" parameterType="java.util.HashMap" resultMap="JobUser">
@@ -84,6 +90,16 @@
         WHERE t.id = #{userId}
     </select>
 
+    <select id="getUserByAccesskey" parameterType="java.util.HashMap" resultMap="JobUser">
+        SELECT
+        t.id,
+        t.username,
+		t.secretkey,
+		t.role
+        FROM job_user AS t
+        WHERE t.accesskey = #{accesskey}
+    </select>
+
     <insert id="save" parameterType="com.wugui.datax.admin.entity.JobUser" useGeneratedKeys="true" keyProperty="id" >
 		INSERT INTO job_user (
 			username,
@@ -106,6 +122,13 @@
         </if>
         role = #{role},
         permission = #{permission}
+        WHERE id = #{id}
+    </update>
+
+    <update id="updateKey" parameterType="com.wugui.datax.admin.entity.JobUser" >
+        UPDATE job_user
+        SET accesskey = #{accesskey},
+            secretkey = #{secretkey}
         WHERE id = #{id}
     </update>
 

--- a/datax-web-sdk-spring-boot-starter/pom.xml
+++ b/datax-web-sdk-spring-boot-starter/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>datax-web</artifactId>
+        <groupId>com.wugui</groupId>
+        <version>2.1.2</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>datax-web-sdk-spring-boot-starter</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.wugui</groupId>
+            <artifactId>datax-web-sdk</artifactId>
+            <version>2.1.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <version>${spring-boot.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+            <version>${spring-boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/datax-web-sdk-spring-boot-starter/src/main/java/com/wugui/datax/client/starter/config/SdkConfig.java
+++ b/datax-web-sdk-spring-boot-starter/src/main/java/com/wugui/datax/client/starter/config/SdkConfig.java
@@ -1,0 +1,58 @@
+package com.wugui.datax.client.starter.config;
+
+import com.wugui.datax.client.starter.property.URLProperties;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import com.wugui.datax.client.JobClient;
+
+@Configuration
+@EnableConfigurationProperties(URLProperties.class)
+@ConditionalOnProperty(prefix = "datax.web.admin", name = "enabled", havingValue = "true")
+public class SdkConfig {
+	@Autowired
+	private URLProperties urlProperties;
+
+	@Bean
+	public JobClient xxlJobClient() {
+		JobClient client = new JobClient();
+		if (urlProperties.getUrl() == null || urlProperties.getUrl().trim().length() == 0) {
+			throw new RuntimeException("datax.web.admin.url is required!");
+		}
+		if (urlProperties.getAccesskey() == null || urlProperties.getAccesskey().trim().length() == 0) {
+			throw new RuntimeException("datax.web.admin.accessKey is required!");
+		}
+		if (urlProperties.getSecretkey() == null || urlProperties.getSecretkey().trim().length() == 0) {
+			throw new RuntimeException("datax.web.admin.secretKey is required!");
+		}
+		client.setWebUrl(urlProperties.getUrl());
+		URLProperties.Api api = urlProperties.getApi();
+		if (api == null) {
+			return client;
+		}
+		if (api.getAdd() != null && api.getAdd().trim().length() > 0) {
+			client.setAdd(api.getAdd());
+		}
+		if (api.getDelete() != null && api.getDelete().trim().length() > 0) {
+			client.setDelete(api.getDelete());
+		}
+		if (api.getUpdate() != null && api.getUpdate().trim().length() > 0) {
+			client.setUpdate(api.getUpdate());
+		}
+		if (api.getLoadJob() != null && api.getLoadJob().trim().length() > 0) {
+			client.setLoad(api.getLoadJob());
+		}
+		if (api.getStart() != null && api.getStart().trim().length() > 0) {
+			client.setStart(api.getStart());
+		}
+		if (api.getStop() != null && api.getStop().trim().length() > 0) {
+			client.setStop(api.getStop());
+		}
+		if (api.getLog() != null && api.getLog().trim().length() > 0) {
+			client.setLog(api.getLog());
+		}
+		return client;
+	}
+}

--- a/datax-web-sdk-spring-boot-starter/src/main/java/com/wugui/datax/client/starter/property/URLProperties.java
+++ b/datax-web-sdk-spring-boot-starter/src/main/java/com/wugui/datax/client/starter/property/URLProperties.java
@@ -1,0 +1,124 @@
+package com.wugui.datax.client.starter.property;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * datax-web定时调度SDK starter配置类
+ *
+ * @author Locki
+ * @date 2020/9/23
+ */
+@ConfigurationProperties(prefix = "datax.web.admin")
+public class URLProperties {
+    private boolean enabled = false;
+    private String accesskey;
+    private String secretkey;
+    private String url;
+    private Api api;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public String getAccesskey() {
+        return accesskey;
+    }
+
+    public void setAccesskey(String accesskey) {
+        this.accesskey = accesskey;
+    }
+
+    public String getSecretkey() {
+        return secretkey;
+    }
+
+    public void setSecretkey(String secretkey) {
+        this.secretkey = secretkey;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public Api getApi() {
+        return api;
+    }
+
+    public void setApi(Api api) {
+        this.api = api;
+    }
+
+    public static class Api {
+        private String add = null;
+        private String loadJob = null;
+        private String update = null;
+        private String delete = null;
+        private String start = null;
+        private String stop = null;
+        private String log = null;
+
+        public String getAdd() {
+            return add;
+        }
+
+        public void setAdd(String add) {
+            this.add = add;
+        }
+
+        public String getLoadJob() {
+            return loadJob;
+        }
+
+        public void setLoadJob(String loadJob) {
+            this.loadJob = loadJob;
+        }
+
+        public String getUpdate() {
+            return update;
+        }
+
+        public void setUpdate(String update) {
+            this.update = update;
+        }
+
+        public String getDelete() {
+            return delete;
+        }
+
+        public void setDelete(String delete) {
+            this.delete = delete;
+        }
+
+        public String getStart() {
+            return start;
+        }
+
+        public void setStart(String start) {
+            this.start = start;
+        }
+
+        public String getStop() {
+            return stop;
+        }
+
+        public void setStop(String stop) {
+            this.stop = stop;
+        }
+
+        public String getLog() {
+            return log;
+        }
+
+        public void setLog(String log) {
+            this.log = log;
+        }
+    }
+}

--- a/datax-web-sdk-spring-boot-starter/src/main/resources/META-INF/spring.factories
+++ b/datax-web-sdk-spring-boot-starter/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=com.wugui.datax.client.starter.config.SdkConfig

--- a/datax-web-sdk-spring-boot-starter/src/test/java/ClientTest.java
+++ b/datax-web-sdk-spring-boot-starter/src/test/java/ClientTest.java
@@ -1,0 +1,78 @@
+import com.wugui.datax.client.JobClient;
+import com.wugui.datax.client.enums.ExecutorBlockStrategyEnum;
+import com.wugui.datax.client.enums.ExecutorRouteStrategyEnum;
+import com.wugui.datax.client.model.JobInfo;
+import org.junit.Test;
+
+public class ClientTest {
+	@Test
+	public void addJob() {
+		JobInfo jobInfo = new JobInfo();
+		//jobInfo.setAlarmEmail("Locki@xxx.com");
+		jobInfo.setAuthor("Locki");
+		jobInfo.setExecutorBlockStrategy(ExecutorBlockStrategyEnum.SERIAL_EXECUTION);
+		jobInfo.setExecutorFailRetryCount(0);
+		jobInfo.setExecutorHandler("procedureHandler");
+		jobInfo.setExecutorParam("{\"type\":\" DB2\",\"url\":\"jdbc:db2://10.0.0.65:50000/DATANALY\",\"user\":\"db2admin\",\"code\":\"db2admin\",\"pros\":[\"PD_ZM_K_RLIC_D\",\"PD_ZM_K_CASEINFO_D(5)\"]}");
+		jobInfo.setExecutorRouteStrategy(ExecutorRouteStrategyEnum.FIRST);
+		jobInfo.setExecutorTimeout(0);
+		jobInfo.setJobCron("0 0 12 * * ? *");
+		jobInfo.setJobDesc("system测试任务");
+		jobInfo.setJobGroup(1);
+		jobInfo.setProjectId("1");
+		
+		JobClient client = new JobClient();
+		System.out.println(client.createJob(jobInfo));
+	}
+	
+	@Test
+	public void updateJob() {
+		JobInfo jobInfo = new JobInfo();
+		jobInfo.setId(38);
+		jobInfo.setAlarmEmail("Locki@xxx.com");
+		jobInfo.setAuthor("Locki");
+		jobInfo.setExecutorBlockStrategy(ExecutorBlockStrategyEnum.SERIAL_EXECUTION);
+		jobInfo.setExecutorFailRetryCount(0);
+		jobInfo.setExecutorHandler("procedureHandler");
+		jobInfo.setExecutorParam("{\"type\":\"DB2\",\"url\":\"jdbc:db2://10.0.0.65:50000/DATANALY\",\"user\":\"db2admin\",\"code\":\"db2admin\",\"pros\":[\"PD_ZM_K_RLIC_D\",\"PD_ZM_K_CASEINFO_D(5)\"]}");
+		jobInfo.setExecutorRouteStrategy(ExecutorRouteStrategyEnum.FIRST);
+		jobInfo.setExecutorTimeout(0);
+		jobInfo.setJobCron("0 0/2 * * * ? *");
+		jobInfo.setJobDesc("system测试任务");
+		jobInfo.setJobGroup(1);
+		jobInfo.setProjectId("1");
+		
+		JobClient client = new JobClient();
+		System.out.println(client.updateJob(jobInfo));
+	}
+	
+	@Test
+	public void startJob() {
+		JobClient client = new JobClient();
+		System.out.println(client.startJob(37 + ""));
+	}
+	
+	@Test
+	public void stopJob() {
+		JobClient client = new JobClient();
+		System.out.println(client.stopJob(37 + ""));
+	}
+	
+	@Test
+	public void removeJob() {
+		JobClient client = new JobClient();
+		System.out.println(client.deleteJob(37 + ""));
+	}
+	
+	@Test
+	public void loadJob() {
+		JobClient client = new JobClient();
+		System.out.println(client.getJob(37 + ""));
+	}
+	
+	@Test
+	public void jobLog() {
+		JobClient client = new JobClient();
+		System.out.println(client.jobLog(36 + ""));
+	}
+}

--- a/datax-web-sdk/pom.xml
+++ b/datax-web-sdk/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>datax-web</artifactId>
+        <groupId>com.wugui</groupId>
+        <version>2.1.2</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>datax-web-sdk</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>cn.hutool</groupId>
+            <artifactId>hutool-all</artifactId>
+            <version>${hutool.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.6</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/datax-web-sdk/src/main/java/com/wugui/datax/client/JobClient.java
+++ b/datax-web-sdk/src/main/java/com/wugui/datax/client/JobClient.java
@@ -1,0 +1,324 @@
+package com.wugui.datax.client;
+
+import cn.hutool.json.JSONObject;
+import com.wugui.datax.client.enums.GlueTypeEnum;
+import com.wugui.datax.client.model.ReturnT;
+import com.wugui.datax.client.model.JobInfo;
+import com.wugui.datax.client.model.JobLog;
+import com.wugui.datax.client.util.AppUtil;
+import com.wugui.datax.client.util.HttpUtil;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ResourceBundle;
+
+/**
+ * datax-web sdk调用客户端
+ *
+ * @author Locki
+ * @date 2020/9/23
+ */
+public class JobClient {
+    private ResourceBundle rb = ResourceBundle.getBundle("sdk-config");
+    private String accessKey = rb.getString("datax.web.admin.accessKey");
+    private String secretKey = rb.getString("datax.web.admin.secretKey");
+    private String webUrl = rb.getString("datax.web.admin.url");
+    private String add = rb.getString("datax.web.admin.api.add");
+    private String load = rb.getString("datax.web.admin.api.loadJob");
+    private String update = rb.getString("datax.web.admin.api.update");
+    private String delete = rb.getString("datax.web.admin.api.delete");
+    private String start = rb.getString("datax.web.admin.api.start");
+    private String stop = rb.getString("datax.web.admin.api.stop");
+    private String log = rb.getString("datax.web.admin.api.log");
+
+    public String getAccessKey() {
+        return accessKey;
+    }
+
+    public void setAccessKey(String accessKey) {
+        this.accessKey = accessKey;
+    }
+
+    public String getSecretKey() {
+        return secretKey;
+    }
+
+    public void setSecretKey(String secretKey) {
+        this.secretKey = secretKey;
+    }
+
+    public String getWebUrl() {
+        return webUrl;
+    }
+
+    public void setWebUrl(String webUrl) {
+        this.webUrl = webUrl;
+    }
+
+    public String getAdd() {
+        return add;
+    }
+
+    public void setAdd(String add) {
+        this.add = add;
+    }
+
+    public String getLoad() {
+        return load;
+    }
+
+    public void setLoad(String load) {
+        this.load = load;
+    }
+
+    public String getUpdate() {
+        return update;
+    }
+
+    public void setUpdate(String update) {
+        this.update = update;
+    }
+
+    public String getDelete() {
+        return delete;
+    }
+
+    public void setDelete(String delete) {
+        this.delete = delete;
+    }
+
+    public String getStart() {
+        return start;
+    }
+
+    public void setStart(String start) {
+        this.start = start;
+    }
+
+    public String getStop() {
+        return stop;
+    }
+
+    public void setStop(String stop) {
+        this.stop = stop;
+    }
+
+    public String getLog() {
+        return log;
+    }
+
+    public void setLog(String log) {
+        this.log = log;
+    }
+
+    /**
+     * API调用返回值封装
+     *
+     * @param result
+     * @return
+     */
+    private ReturnT returns(String result) {
+        ReturnT returnT = null;
+        JSONObject object = new JSONObject(result);
+        if ("200".equals(object.getStr("code"))) {
+            returnT = new ReturnT(true, object.getStr("msg"), object.getStr("content"));
+        } else {
+            returnT = new ReturnT(false, object.getStr("msg"), object.getStr("content"));
+        }
+        return returnT;
+    }
+
+    /**
+     * 添加任务
+     *
+     * @param jobInfo
+     * @return
+     */
+    public ReturnT createJob(JobInfo jobInfo) {
+        String url = webUrl + add;
+        ReturnT returnT = null;
+        try {
+            Map<String, String> paramMap = jobToMap(jobInfo);
+            String result = new HttpUtil().postJson(url, addSign(paramMap));
+            returnT = returns(result);
+        } catch (Exception e) {
+            e.printStackTrace();
+            returnT = new ReturnT(false, e.getMessage(), null);
+        }
+        return returnT;
+    }
+
+    /**
+     * 修改任务
+     *
+     * @param jobInfo
+     * @return
+     */
+    public ReturnT updateJob(JobInfo jobInfo) {
+        String url = webUrl + update;
+        ReturnT returnT = null;
+        try {
+            Map<String, String> paramMap = jobToMap(jobInfo);
+            String result = new HttpUtil().postJson(url, addSign(paramMap));
+            returnT = returns(result);
+        } catch (Exception e) {
+            e.printStackTrace();
+            returnT = new ReturnT(false, e.getMessage(), null);
+        }
+        return returnT;
+    }
+
+    /**
+     * 删除任务
+     *
+     * @param id
+     * @return
+     */
+    public ReturnT deleteJob(String id) {
+        String url = webUrl + delete + "/" + id;
+        ReturnT returnT = null;
+        try {
+            Map<String, String> paramMap = new HashMap<String, String>();
+            paramMap.put("id", id);
+            String result = new HttpUtil().postJson(url, addSign(paramMap));
+            returnT = returns(result);
+        } catch (Exception e) {
+            e.printStackTrace();
+            returnT = new ReturnT(false, e.getMessage(), null);
+        }
+        return returnT;
+    }
+
+    /**
+     * 查询任务
+     *
+     * @param id
+     * @return
+     * @throws Exception
+     */
+    public JobInfo getJob(String id) {
+        String url = webUrl + load + "?id=" + id;
+        JobInfo jobInfo = null;
+        try {
+            Map<String, String> paramMap = new HashMap<String, String>();
+            paramMap.put("id", id);
+            String result = new HttpUtil().postJson(url, addSign(paramMap));
+            JSONObject object = new JSONObject(result);
+            jobInfo = object.toBean(JobInfo.class);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return jobInfo;
+    }
+
+    /**
+     * 停用任务
+     *
+     * @param id
+     * @return
+     */
+    public ReturnT stopJob(String id) {
+        String url = webUrl + stop + "?id=" + id;
+        ReturnT returnT = null;
+        try {
+            Map<String, String> paramMap = new HashMap<String, String>();
+            paramMap.put("id", id);
+            String result = new HttpUtil().postJson(url, addSign(paramMap));
+            returnT = returns(result);
+        } catch (Exception e) {
+            e.printStackTrace();
+            returnT = new ReturnT(false, e.getMessage(), null);
+        }
+        return returnT;
+    }
+
+    /**
+     * 启用任务
+     *
+     * @param id
+     * @return
+     */
+    public ReturnT startJob(String id) {
+        String url = webUrl + start + "?id=" + id;
+        ReturnT returnT = null;
+        try {
+            Map<String, String> paramMap = new HashMap<String, String>();
+            paramMap.put("id", id);
+            String result = new HttpUtil().postJson(url, addSign(paramMap));
+            returnT = returns(result);
+        } catch (Exception e) {
+            e.printStackTrace();
+            returnT = new ReturnT(false, e.getMessage(), null);
+        }
+        return returnT;
+    }
+
+    /**
+     * 任务执行日志
+     *
+     * @param id
+     * @return
+     */
+    public List<JobLog> jobLog(String id) {
+        String url = webUrl + log;
+        List<JobLog> logs = null;
+        try {
+            Map<String, String> paramMap = new HashMap<String, String>();
+            paramMap.put("jobId", id);
+            paramMap.put("jobGroup", "0");
+            paramMap.put("logStatus", "-1");
+            String result = new HttpUtil().get(url, addSign(paramMap));
+            JSONObject object = new JSONObject(result);
+            logs = object.getJSONObject("content").getJSONArray("data").toList(JobLog.class);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return logs;
+    }
+
+    /**
+     * 将任务参数转换为Map<String, String>作为http请求参数
+     *
+     * @param jobInfo
+     * @return
+     */
+    private Map<String, String> jobToMap(JobInfo jobInfo) {
+        Map<String, String> map = new HashMap<>();
+        if (jobInfo.getId() > 0) {
+            map.put("id", String.valueOf(jobInfo.getId()));
+        }
+        map.put("jobGroup", String.valueOf(jobInfo.getJobGroup()));
+        map.put("jobCron", jobInfo.getJobCron());
+        map.put("jobDesc", jobInfo.getJobDesc());
+        map.put("projectId", jobInfo.getProjectId());
+        map.put("author", jobInfo.getAuthor());
+        map.put("alarmEmail", jobInfo.getAlarmEmail());
+        map.put("executorRouteStrategy", String.valueOf(jobInfo.getExecutorRouteStrategy()));
+        map.put("executorHandler", jobInfo.getExecutorHandler());
+        map.put("executorBlockStrategy", String.valueOf(jobInfo.getExecutorBlockStrategy()));
+        map.put("executorTimeout", String.valueOf(jobInfo.getExecutorTimeout()));
+        map.put("executorFailRetryCount", String.valueOf(jobInfo.getExecutorFailRetryCount()));
+        //通过SDK只能添加JAVA_BEAN类型
+        map.put("glueType", GlueTypeEnum.JAVA_BEAN.name());
+        map.put("executorParam", jobInfo.getExecutorParam());
+        map.put("jobJson", jobInfo.getExecutorParam());
+        return map;
+    }
+
+    /**
+     * 签名
+     *
+     * @param params
+     * @return {@link Map< String, String>}
+     * @author jiangyang
+     * @date 2020/10/15
+     */
+    private Map<String, String> addSign(Map<String, String> params) {
+        params.put("timestamp", System.currentTimeMillis() + "");
+        params.put("accessKey", this.accessKey);
+        String sign = AppUtil.sign(params, this.secretKey);
+        params.put("sign", sign);
+        return params;
+    }
+}

--- a/datax-web-sdk/src/main/java/com/wugui/datax/client/enums/ExecutorBlockStrategyEnum.java
+++ b/datax-web-sdk/src/main/java/com/wugui/datax/client/enums/ExecutorBlockStrategyEnum.java
@@ -1,0 +1,43 @@
+package com.wugui.datax.client.enums;
+
+/**
+ * Created by xuxueli on 17/5/9.
+ */
+public enum ExecutorBlockStrategyEnum {
+	/**
+	 * 单机串行
+	 */
+    SERIAL_EXECUTION("单机串行"),
+    /*CONCURRENT_EXECUTION("并行"),*/
+    /**
+     * 丢弃后续调度
+     */
+    DISCARD_LATER("丢弃后续调度"),
+    /**
+     * 覆盖之前调度
+     */
+    COVER_EARLY("覆盖之前调度");
+
+    private String title;
+    private ExecutorBlockStrategyEnum (String title) {
+        this.title = title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+    public String getTitle() {
+        return title;
+    }
+
+    public static ExecutorBlockStrategyEnum match(String name, ExecutorBlockStrategyEnum defaultItem) {
+        if (name != null) {
+            for (ExecutorBlockStrategyEnum item:ExecutorBlockStrategyEnum.values()) {
+                if (item.name().equals(name)) {
+                    return item;
+                }
+            }
+        }
+        return defaultItem;
+    }
+}

--- a/datax-web-sdk/src/main/java/com/wugui/datax/client/enums/ExecutorRouteStrategyEnum.java
+++ b/datax-web-sdk/src/main/java/com/wugui/datax/client/enums/ExecutorRouteStrategyEnum.java
@@ -1,0 +1,68 @@
+package com.wugui.datax.client.enums;
+
+/**
+ * Created by xuxueli on 17/3/10.
+ */
+public enum ExecutorRouteStrategyEnum {
+	/**
+	 * 第一个
+	 */
+	FIRST("第一个"),
+	/**
+	 * 最后一个
+	 */
+	LAST("最后一个"),
+	/**
+	 * 轮询
+	 */
+	ROUND("轮询"),
+	/**
+	 * 随机
+	 */
+	RANDOM("随机"),
+	/**
+	 * 一致性HASH
+	 */
+	CONSISTENT_HASH("一致性HASH"),
+	/**
+	 * 最不经常使用
+	 */
+	LEAST_FREQUENTLY_USED("最不经常使用"),
+	/**
+	 * 最近最久未使用
+	 */
+	LEAST_RECENTLY_USED("最近最久未使用"),
+	/**
+	 * 故障转移
+	 */
+	FAILOVER("故障转移"),
+	/**
+	 * 忙碌转移
+	 */
+	BUSYOVER("忙碌转移"),
+	/**
+	 * 分片广播
+	 */
+	SHARDING_BROADCAST("分片广播");
+
+	ExecutorRouteStrategyEnum(String title) {
+		this.title = title;
+	}
+
+	private String title;
+
+	public String getTitle() {
+		return title;
+	}
+
+	public static ExecutorRouteStrategyEnum match(String name, ExecutorRouteStrategyEnum defaultItem) {
+		if (name != null) {
+			for (ExecutorRouteStrategyEnum item : ExecutorRouteStrategyEnum.values()) {
+				if (item.name().equals(name)) {
+					return item;
+				}
+			}
+		}
+		return defaultItem;
+	}
+}

--- a/datax-web-sdk/src/main/java/com/wugui/datax/client/enums/GlueTypeEnum.java
+++ b/datax-web-sdk/src/main/java/com/wugui/datax/client/enums/GlueTypeEnum.java
@@ -1,0 +1,54 @@
+package com.wugui.datax.client.enums;
+
+/**
+ * Created by xuxueli on 17/4/26.
+ */
+public enum GlueTypeEnum {
+
+    JAVA_BEAN("JAVA_BEAN", false, null, null),
+    DATAX("DATAX", false, null, null),
+    GLUE_GROOVY("GLUE(Java)", false, null, null),
+    GLUE_SHELL("GLUE(Shell)", true, "bash", ".sh"),
+    GLUE_PYTHON("GLUE(Python)", true, "python", ".py"),
+    GLUE_PHP("GLUE(PHP)", true, "php", ".php"),
+    GLUE_NODEJS("GLUE(Nodejs)", true, "node", ".js"),
+    GLUE_POWERSHELL("GLUE(PowerShell)", true, "powershell", ".ps1");
+
+    private String desc;
+    private boolean isScript;
+    private String cmd;
+    private String suffix;
+
+    private GlueTypeEnum(String desc, boolean isScript, String cmd, String suffix) {
+        this.desc = desc;
+        this.isScript = isScript;
+        this.cmd = cmd;
+        this.suffix = suffix;
+    }
+
+    public String getDesc() {
+        return desc;
+    }
+
+    public boolean isScript() {
+        return isScript;
+    }
+
+    public String getCmd() {
+        return cmd;
+    }
+
+    public String getSuffix() {
+        return suffix;
+    }
+
+    public static GlueTypeEnum match(String name){
+        for (GlueTypeEnum item: GlueTypeEnum.values()) {
+            if (item.name().equals(name)) {
+                return item;
+            }
+        }
+        return null;
+    }
+
+}

--- a/datax-web-sdk/src/main/java/com/wugui/datax/client/enums/JobAlarmerEnum.java
+++ b/datax-web-sdk/src/main/java/com/wugui/datax/client/enums/JobAlarmerEnum.java
@@ -1,0 +1,33 @@
+package com.wugui.datax.client.enums;
+
+/**
+ * @author Locki 2020-05-13
+ */
+public enum JobAlarmerEnum {
+	EMAIL("邮件通知"), RPC("RPC通知");
+
+	JobAlarmerEnum(String title) {
+		this.title = title;
+	}
+
+	private String title;
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public static JobAlarmerEnum match(String name, JobAlarmerEnum defaultItem) {
+		if (name != null) {
+			for (JobAlarmerEnum item : JobAlarmerEnum.values()) {
+				if (item.name().equals(name)) {
+					return item;
+				}
+			}
+		}
+		return defaultItem;
+	}
+}

--- a/datax-web-sdk/src/main/java/com/wugui/datax/client/model/JobInfo.java
+++ b/datax-web-sdk/src/main/java/com/wugui/datax/client/model/JobInfo.java
@@ -1,0 +1,424 @@
+package com.wugui.datax.client.model;
+
+import com.wugui.datax.client.enums.ExecutorBlockStrategyEnum;
+import com.wugui.datax.client.enums.ExecutorRouteStrategyEnum;
+import com.wugui.datax.client.enums.GlueTypeEnum;
+
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * xxl-job info
+ *
+ * @author xuxueli 2016-1-12 18:25:49
+ */
+public class JobInfo implements Serializable{
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * 主键ID
+	 */
+	private int id;
+	/**
+	 * 执行器主键ID
+	 */
+	private int jobGroup;
+	/**
+	 * 任务执行CRON表达式
+	 */
+	private String jobCron;
+	/**
+	 * 任务描述
+	 */
+	private String jobDesc;
+	/**
+	 * 所属项目
+	 */
+	private String projectId;
+	/**
+	 * 创建时间
+	 */
+	private Date addTime;
+	/**
+	 * 修改时间
+	 */
+	private Date updateTime;
+	/**
+	 * 负责人
+	 */
+	private String author = "system";
+	/**
+	 * 邮件报警地址
+	 */
+	private String alarmEmail;
+	/**
+	 * 执行器路由策略
+	 */
+	private String executorRouteStrategy = ExecutorRouteStrategyEnum.FIRST.name();
+	/**
+	 * 执行器，任务Handler名称
+	 */
+	private String executorHandler;
+	/**
+	 * 执行器，任务参数
+	 */
+	@Deprecated
+	private String executorParam;
+	/**
+	 * 阻塞处理策略
+	 */
+	private String executorBlockStrategy = ExecutorBlockStrategyEnum.SERIAL_EXECUTION.name();
+	/**
+	 * 任务执行超时时间，单位秒
+	 */
+	private int executorTimeout;
+	/**
+	 * 失败重试次数
+	 */
+	private int executorFailRetryCount;
+	/**
+	 * GLUE类型
+	 */
+	private String glueType;
+	/**
+	 * 调度状态：0-停止，1-运行
+	 */
+	private int triggerStatus;
+	/**
+	 * 上次调度时间
+	 */
+	private long triggerLastTime;
+	/**
+	 * 下次调度时间
+	 */
+	private long triggerNextTime;
+
+	/**
+	 * 获取任务主键
+	 *
+	 * @return
+	 */
+	public int getId() {
+		return id;
+	}
+
+	/**
+	 * 设置任务主键
+	 *
+	 * @param id
+	 */
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	/**
+	 * 获取执行器id
+	 *
+	 * @return
+	 */
+	public int getJobGroup() {
+		return jobGroup;
+	}
+
+	/**
+	 * 设置执行器id，暂不开放此功能；执行器id目前统一在创建JobClient时指定
+	 *
+	 * @param jobGroup
+	 */
+	public void setJobGroup(int jobGroup) {
+		this.jobGroup = jobGroup;
+	}
+
+	/**
+	 * 获取任务执行的CRON表达式
+	 *
+	 * @return
+	 */
+	public String getJobCron() {
+		return jobCron;
+	}
+
+	/**
+	 * 设置任务执行的CRON表达式
+	 *
+	 * @param jobCron
+	 */
+	public void setJobCron(String jobCron) {
+		this.jobCron = jobCron;
+	}
+
+	/**
+	 * 获取任务描述
+	 *
+	 * @return
+	 */
+	public String getJobDesc() {
+		return jobDesc;
+	}
+
+	/**
+	 * 设置任务描述
+	 *
+	 * @param jobDesc
+	 */
+	public void setJobDesc(String jobDesc) {
+		this.jobDesc = jobDesc;
+	}
+
+	/**
+	 * 获取所属项目
+	 * @return
+	 */
+	public String getProjectId() {
+		return projectId;
+	}
+
+	/**
+	 * 设置所属项目
+	 * @param projectId
+	 */
+	public void setProjectId(String projectId) {
+		this.projectId = projectId;
+	}
+
+	/**
+	 * 获取任务创建时间
+	 *
+	 * @return
+	 */
+	public Date getAddTime() {
+		return addTime;
+	}
+
+	/**
+	 * 获取任务修改时间
+	 *
+	 * @return
+	 */
+	public Date getUpdateTime() {
+		return updateTime;
+	}
+
+	/**
+	 * 获取任务负责人
+	 *
+	 * @return
+	 */
+	public String getAuthor() {
+		return author;
+	}
+
+	/**
+	 * 设置任务负责人，默认system
+	 *
+	 * @param author
+	 */
+	public void setAuthor(String author) {
+		this.author = author;
+	}
+
+	/**
+	 * 获取报警邮件地址
+	 *
+	 * @return
+	 */
+	public String getAlarmEmail() {
+		return alarmEmail;
+	}
+
+	/**
+	 * 设置报警邮件地址
+	 *
+	 * @param alarmEmail
+	 */
+	public void setAlarmEmail(String alarmEmail) {
+		this.alarmEmail = alarmEmail;
+	}
+
+	/**
+	 * 获取路由策略
+	 *
+	 * @return
+	 */
+	public ExecutorRouteStrategyEnum getExecutorRouteStrategy() {
+		return ExecutorRouteStrategyEnum.match(executorRouteStrategy, ExecutorRouteStrategyEnum.FIRST);
+	}
+
+	/**
+	 * 设置路由策略，默认第一个
+	 *
+	 * @param executorRouteStrategy
+	 */
+	public void setExecutorRouteStrategy(ExecutorRouteStrategyEnum executorRouteStrategy) {
+		this.executorRouteStrategy = executorRouteStrategy.name();
+	}
+
+	/**
+	 * 获取BEAN模式运行的JobHandler
+	 *
+	 * @return
+	 */
+	public String getExecutorHandler() {
+		return executorHandler;
+	}
+
+	/**
+	 * 设置BEAN模式运行的JobHandler
+	 *
+	 * @param executorHandler
+	 */
+	public void setExecutorHandler(String executorHandler) {
+		this.executorHandler = executorHandler;
+	}
+
+	/**
+	 * 获取运行参数
+	 *
+	 * @return
+	 */
+	public String getExecutorParam() {
+		return executorParam;
+	}
+
+	/**
+	 * 设置运行参数
+	 *
+	 * @param executorParam
+	 */
+	public void setExecutorParam(String executorParam) {
+		this.executorParam = executorParam;
+	}
+
+	/**
+	 * 获取阻塞处理策略
+	 *
+	 * @return
+	 */
+	public ExecutorBlockStrategyEnum getExecutorBlockStrategy() {
+		return ExecutorBlockStrategyEnum.match(executorBlockStrategy, ExecutorBlockStrategyEnum.SERIAL_EXECUTION);
+	}
+
+	/**
+	 * 设置阻塞处理策略，默认单机串行
+	 *
+	 * @param executorBlockStrategy
+	 */
+	public void setExecutorBlockStrategy(ExecutorBlockStrategyEnum executorBlockStrategy) {
+		this.executorBlockStrategy = executorBlockStrategy.name();
+	}
+
+	/**
+	 * 获取任务超时时间
+	 *
+	 * @return
+	 */
+	public int getExecutorTimeout() {
+		return executorTimeout;
+	}
+
+	/**
+	 * 设置任务超时时间，默认0，即不设置超时
+	 *
+	 * @param executorTimeout
+	 */
+	public void setExecutorTimeout(int executorTimeout) {
+		this.executorTimeout = executorTimeout;
+	}
+
+	/**
+	 * 获取失败重试次数
+	 *
+	 * @return
+	 */
+	public int getExecutorFailRetryCount() {
+		return executorFailRetryCount;
+	}
+
+	/**
+	 * 设置失败重试次数，默认0，即不重试
+	 *
+	 * @param executorFailRetryCount
+	 */
+	public void setExecutorFailRetryCount(int executorFailRetryCount) {
+		this.executorFailRetryCount = executorFailRetryCount;
+	}
+
+	/**
+	 * 获取任务运行模式，SDK仅提供BEAN模式
+	 *
+	 * @return
+	 */
+	public String getGlueType() {
+		return glueType;
+	}
+
+	/**
+	 * 获取调度状态：0-停止，1-运行
+	 *
+	 * @return
+	 */
+	public int getTriggerStatus() {
+		return triggerStatus;
+	}
+
+	/**
+	 * 获取上次调度时间
+	 *
+	 * @return
+	 */
+	public long getTriggerLastTime() {
+		return triggerLastTime;
+	}
+
+	public void setAddTime(Date addTime) {
+		this.addTime = addTime;
+	}
+
+	public void setUpdateTime(Date updateTime) {
+		this.updateTime = updateTime;
+	}
+
+	public void setExecutorRouteStrategy(String executorRouteStrategy) {
+		this.executorRouteStrategy = executorRouteStrategy;
+	}
+
+	public void setExecutorBlockStrategy(String executorBlockStrategy) {
+		this.executorBlockStrategy = executorBlockStrategy;
+	}
+
+	public void setGlueType(String glueType) {
+		this.glueType = glueType;
+	}
+
+	public void setTriggerStatus(int triggerStatus) {
+		this.triggerStatus = triggerStatus;
+	}
+
+	public void setTriggerLastTime(long triggerLastTime) {
+		this.triggerLastTime = triggerLastTime;
+	}
+
+	public void setTriggerNextTime(long triggerNextTime) {
+		this.triggerNextTime = triggerNextTime;
+	}
+
+	/**
+	 * 获取下次调度时间
+	 *
+	 * @return
+	 */
+	public long getTriggerNextTime() {
+		return triggerNextTime;
+	}
+
+	@Override
+	public String toString() {
+		return "JobInfo [id=" + id + ", jobGroup=" + jobGroup + ", jobCron=" + jobCron + ", jobDesc=" + jobDesc
+				+ ", addTime=" + addTime + ", updateTime=" + updateTime + ", author=" + author + ", alarmEmail="
+				+ alarmEmail + ", executorRouteStrategy=" + executorRouteStrategy + ", executorHandler="
+				+ executorHandler + ", executorParam=" + executorParam + ", executorBlockStrategy="
+				+ executorBlockStrategy + ", executorTimeout=" + executorTimeout + ", executorFailRetryCount="
+				+ executorFailRetryCount + ", glueType=" + glueType + ", triggerStatus=" + triggerStatus
+				+ ", triggerLastTime=" + triggerLastTime + ", triggerNextTime=" + triggerNextTime + "]";
+	}
+}

--- a/datax-web-sdk/src/main/java/com/wugui/datax/client/model/JobLog.java
+++ b/datax-web-sdk/src/main/java/com/wugui/datax/client/model/JobLog.java
@@ -1,0 +1,45 @@
+package com.wugui.datax.client.model;
+
+import lombok.Data;
+
+import java.util.Date;
+
+/**
+ * datax-web log, used to track trigger process
+ *
+ * @author jingwk  2019-11-17 22:08:11
+ */
+@Data
+public class JobLog {
+
+    private long id;
+
+    // job info
+    private int jobGroup;
+    private int jobId;
+    private String jobDesc;
+
+    // execute info
+    private String executorAddress;
+    private String executorHandler;
+    private String executorParam;
+    private String executorShardingParam;
+    private int executorFailRetryCount;
+
+    // trigger info
+    private Date triggerTime;
+    private int triggerCode;
+    private String triggerMsg;
+
+    // handle info
+    private Date handleTime;
+    private int handleCode;
+    private String handleMsg;
+
+    // alarm info
+    private int alarmStatus;
+
+    private String processId;
+
+    private Long maxId;
+}

--- a/datax-web-sdk/src/main/java/com/wugui/datax/client/model/ReturnT.java
+++ b/datax-web-sdk/src/main/java/com/wugui/datax/client/model/ReturnT.java
@@ -1,0 +1,46 @@
+package com.wugui.datax.client.model;
+
+public class ReturnT {
+
+	private boolean isSuccess;
+	private String msg;
+	private String content;
+
+	public ReturnT() {
+	}
+
+	public ReturnT(boolean isSuccess, String msg, String content) {
+		this.isSuccess = isSuccess;
+		this.msg = msg;
+		this.content = content;
+	}
+
+	public boolean isSuccess() {
+		return isSuccess;
+	}
+
+	public void setSuccess(boolean isSuccess) {
+		this.isSuccess = isSuccess;
+	}
+
+	public String getMsg() {
+		return msg;
+	}
+
+	public void setMsg(String msg) {
+		this.msg = msg;
+	}
+
+	public String getContent() {
+		return content;
+	}
+
+	public void setContent(String content) {
+		this.content = content;
+	}
+
+	@Override
+	public String toString() {
+		return "ReturnT [isSuccess=" + isSuccess + ", msg=" + msg + ", content=" + content + "]";
+	}
+}

--- a/datax-web-sdk/src/main/java/com/wugui/datax/client/util/AppUtil.java
+++ b/datax-web-sdk/src/main/java/com/wugui/datax/client/util/AppUtil.java
@@ -1,0 +1,125 @@
+package com.wugui.datax.client.util;
+
+import cn.hutool.crypto.digest.DigestUtil;
+
+import java.util.*;
+
+/**
+ * 应用接入AccessKey/SecretKey工具类
+ *
+ * @author Locki
+ * @date 2020/10/13
+ */
+public class AppUtil {
+    //生成 SecretKey 密钥
+    private final static String SERVER_NAME = "datax_web_api_1234567809";
+    private final static String[] chars = new String[]{"a", "b", "c", "d", "e", "f",
+            "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s",
+            "t", "u", "v", "w", "x", "y", "z", "0", "1", "2", "3", "4", "5",
+            "6", "7", "8", "9", "A", "B", "C", "D", "E", "F", "G", "H", "I",
+            "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V",
+            "W", "X", "Y", "Z"};
+
+    /**
+     * @Description: <p>
+     * 短8位UUID思想其实借鉴微博短域名的生成方式，但是其重复概率过高，而且每次生成4个，需要随即选取一个。
+     * 本算法利用62个可打印字符，通过随机生成32位UUID，由于UUID都为十六进制，所以将UUID分成8组，每4个为一组，然后通过模62操作，结果作为索引取出字符，
+     * 这样重复率大大降低。
+     * 经测试，在生成一千万个数据也没有出现重复，完全满足大部分需求。
+     * </p>
+     * @author mazhq
+     * @date 2019/8/27 16:16
+     */
+    public static String getAccessKey() {
+        StringBuffer shortBuffer = new StringBuffer();
+        String uuid = UUID.randomUUID().toString().replace("-", "");
+        for (int i = 0; i < 8; i++) {
+            String str = uuid.substring(i * 4, i * 4 + 4);
+            int x = Integer.parseInt(str, 16);
+            shortBuffer.append(chars[x % 0x3E]);
+        }
+        return shortBuffer.toString();
+    }
+
+    /**
+     * <p>
+     * 通过AccessKey、用户名和内置关键词生成SecretKey
+     * </P>
+     *
+     * @author mazhq
+     * @date 2019/8/27 16:32
+     */
+    public static String getSecretKey(String userName, String accessKey) {
+        String[] array = new String[]{userName, accessKey, SERVER_NAME};
+        StringBuffer sb = new StringBuffer();
+        // 字符串排序
+        Arrays.sort(array);
+        for (int i = 0; i < array.length; i++) {
+            sb.append(array[i]);
+        }
+        String str = sb.toString();
+        return DigestUtil.sha1Hex(str);
+    }
+
+    /**
+     * 应用接入签名
+     *
+     * @param params
+     * @param secretKey
+     * @return {@link String}
+     * @author Locki
+     * @date 2020/10/13
+     */
+    public static String sign(Map<String, String> params, String secretKey) {
+        String sign = "";
+        if (params == null || params.size() < 1) {
+            return sign;
+        }
+        Map<String, String> sorted = sortMap(params);
+        StringBuffer sb = new StringBuffer();
+        sorted.forEach((k, v) -> {
+            if (!"sign".equals(k)) {
+                sb.append(k).append("=").append(v == null ? "" : v).append("&");
+            }
+        });
+        sb.append("secretKey").append("=").append(secretKey);
+        sign = DigestUtil.md5Hex(sb.toString()).toUpperCase();
+        return sign;
+
+    }
+
+    /**
+     * Map按照key排序
+     *
+     * @param params
+     * @return {@link Map< String, String>}
+     * @author jiangyang
+     * @date 2020/10/13
+     */
+    public static Map<String, String> sortMap(Map<String, String> params) {
+        Map<String, String> sorted = new LinkedHashMap<>();
+        if (params == null || params.size() < 1) {
+            return sorted;
+        }
+        params.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .forEachOrdered(x -> sorted.put(x.getKey(), x.getValue()));
+        return sorted;
+    }
+
+    public static void main(String[] args) {
+        String accessKey = getAccessKey();
+        String secretKey = getSecretKey("admin", accessKey);
+        System.out.println("accessKey: " + accessKey);
+        System.out.println("secretKey: " + secretKey);
+        System.out.println(System.currentTimeMillis());
+
+        Map<String, String> map = new HashMap<>();
+        map.put("timestamp", "1602727212137");
+        map.put("pageNo", "1");
+        map.put("accessKey", "wj24UV2A");
+        map.put("pageSize", "10");
+        map.put("searchVal", "");
+        System.out.println(sign(map, "bfd81d8725f3a38af0643ea5f910d7c3c7bc6f74"));
+    }
+}

--- a/datax-web-sdk/src/main/java/com/wugui/datax/client/util/HttpUtil.java
+++ b/datax-web-sdk/src/main/java/com/wugui/datax/client/util/HttpUtil.java
@@ -1,0 +1,285 @@
+package com.wugui.datax.client.util;
+
+import cn.hutool.json.JSONObject;
+import cn.hutool.json.JSONUtil;
+
+import java.io.*;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Http连接处理工具类
+ * 
+ * @author lxj
+ *
+ */
+public class HttpUtil {
+	/**
+	 * get方式
+	 * 
+	 * @param targetURL
+	 * @param paramMap
+	 */
+	public String get(String targetURL, Map<String, String> paramMap) throws Exception {
+		HttpURLConnection con = null;
+		try {
+			if (targetURL.indexOf("?") == -1) {
+				targetURL += "?";
+			}
+			targetURL += uriMapToString(paramMap);
+			// 获取链接
+			con = getHttpConnection(targetURL);
+			// 设置提交方式，用户名及密码
+			con.setRequestMethod("GET");
+			con.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
+
+			// 请求返回值不为200，直接退出
+			if (con.getResponseCode() != 200) {
+				throw new RuntimeException("HTTP GET Request Failed with Error code : " + con.getResponseCode());
+			}
+
+			// 获取体信息
+			StringBuffer bufBody = getBodyFieds(con);
+			return bufBody.toString();
+		} catch (Exception e) {
+			throw e;
+		} finally {
+			// 关闭链接
+			disconnect(con);
+		}
+	}
+
+	/**
+	 * post方式-form
+	 * 
+	 * @param targetURL
+	 * @param paramMap
+	 */
+	public String postForm(String targetURL, Map<String, String> paramMap) throws Exception {
+		HttpURLConnection con = null;
+		try {
+			// 获取链接
+			con = getHttpConnection(targetURL);
+			// 设置提交方式，用户名及密码
+			con.setRequestMethod("POST");
+			con.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+			con.setRequestProperty("Accept", "application/json");
+			con.setRequestProperty("Accept-Charset", "UTF-8");
+
+			DataOutputStream out = new DataOutputStream(con.getOutputStream());
+			out.write(uriMapToString(paramMap).getBytes());
+			out.flush();
+			out.close();
+
+			// 请求返回值不为200，直接退出
+			if (con.getResponseCode() != 200) {
+				throw new RuntimeException("HTTP GET Request Failed with Error code : " + con.getResponseCode());
+			}
+			// 获取体信息
+			StringBuffer bufBody = getBodyFieds(con);
+			return bufBody.toString();
+		} catch (Exception e) {
+			throw e;
+		} finally {
+			// 关闭链接
+			disconnect(con);
+		}
+	}
+
+	/**
+	 * post方式-json
+	 *
+	 * @param targetURL
+	 * @param paramMap
+	 */
+	public String postJson(String targetURL, Map<String, String> paramMap) throws Exception {
+		HttpURLConnection con = null;
+		try {
+			// 获取链接
+			con = getHttpConnection(targetURL);
+			con.setDoOutput(true);
+			con.setDoInput(true);
+			// 设置提交方式，用户名及密码
+			con.setRequestMethod("POST");
+			con.setRequestProperty("Content-Type", "application/json;charset=UTF-8");
+			con.setRequestProperty("Accept", "application/json");
+			con.setRequestProperty("Accept-Charset", "UTF-8");
+
+			OutputStreamWriter out = new OutputStreamWriter(con.getOutputStream());
+			String data = JSONUtil.toJsonStr(new JSONObject(paramMap, false));
+			out.write(data);
+			out.flush();
+			out.close();
+
+			// 请求返回值不为200，直接退出
+			if (con.getResponseCode() != 200) {
+				throw new RuntimeException("HTTP GET Request Failed with Error code : " + con.getResponseCode());
+			}
+			// 获取体信息
+			StringBuffer bufBody = getBodyFieds(con);
+			return bufBody.toString();
+		} catch (Exception e) {
+			throw e;
+		} finally {
+			// 关闭链接
+			disconnect(con);
+		}
+	}
+
+	/**
+	 * put方式
+	 * 
+	 * @param targetURL
+	 * @param param
+	 */
+	public String put(String targetURL, Map<String, String> paramMap) throws Exception {
+		HttpURLConnection con = null;
+		try {
+			// 获取链接
+			con = getHttpConnection(targetURL);
+			// 设置提交方式，用户名及密码
+			con.setRequestMethod("PUT");
+			con.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+			con.addRequestProperty("Svc_UserName", "admin");
+			con.addRequestProperty("Svc_Password", "1");
+
+			DataOutputStream out = new DataOutputStream(con.getOutputStream());
+			out.write(uriMapToString(paramMap).getBytes("UTF-8"));
+			out.flush();
+			out.close();
+
+			// 请求返回值不为200，直接退出
+			if (con.getResponseCode() != 200) {
+				throw new RuntimeException("HTTP GET Request Failed with Error code : " + con.getResponseCode());
+			}
+			// 获取体信息
+			StringBuffer bufBody = getBodyFieds(con);
+			return bufBody.toString();
+		} catch (Exception e) {
+			throw e;
+		} finally {
+			// 关闭链接
+			disconnect(con);
+		}
+	}
+
+	/**
+	 * delete方式
+	 * 
+	 * @param targetURL
+	 * @param param
+	 */
+	public String delete(String targetURL, Map<String, String> paramMap) throws Exception {
+		HttpURLConnection con = null;
+		try {
+			if (targetURL.indexOf("?") == -1) {
+				targetURL += "?";
+			}
+			targetURL += uriMapToString(paramMap);
+			// 获取链接
+			con = getHttpConnection(targetURL);
+			// 设置提交方式，用户名及密码
+			con.setRequestMethod("DELETE");
+			con.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
+			con.addRequestProperty("Svc_UserName", "admin");
+			con.addRequestProperty("Svc_Password", "1");
+
+			// 请求返回值不为200，直接退出
+			if (con.getResponseCode() != 200) {
+				throw new RuntimeException("HTTP GET Request Failed with Error code : " + con.getResponseCode());
+			}
+
+			// 获取体信息
+			StringBuffer bufBody = getBodyFieds(con);
+			return bufBody.toString();
+		} catch (Exception e) {
+			throw e;
+		} finally {
+			// 关闭链接
+			disconnect(con);
+		}
+	}
+
+	/**
+	 * 获取链接
+	 * 
+	 * @param targetURL
+	 * @return
+	 */
+	public HttpURLConnection getHttpConnection(String targetURL) throws Exception {
+		HttpURLConnection httpConnection = null;
+		try {
+			URL targetUrl = new URL(targetURL);
+
+			httpConnection = (HttpURLConnection) targetUrl.openConnection();
+			httpConnection.setDoOutput(true);
+			httpConnection.setDoInput(true);
+			httpConnection.setUseCaches(false);
+			httpConnection.setInstanceFollowRedirects(true);
+			httpConnection.setConnectTimeout(5 * 1000);
+		} catch (Exception e) {
+			throw e;
+		}
+		return httpConnection;
+	}
+
+	/**
+	 * 获取体信息
+	 * 
+	 * @param con
+	 * @return
+	 */
+	public StringBuffer getBodyFieds(HttpURLConnection con) throws Exception {
+		StringBuffer output = new StringBuffer();
+		try {
+			BufferedReader br = new BufferedReader(new InputStreamReader((con.getInputStream())));
+			String outStr = "";
+			while ((outStr = br.readLine()) != null) {
+				output.append(outStr).append("\n");
+			}
+		} catch (Exception e) {
+			throw e;
+		}
+		return output;
+	}
+
+	/**
+	 * 关闭链接
+	 * 
+	 * @param con
+	 */
+	public void disconnect(HttpURLConnection con) throws Exception {
+		try {
+			if (con != null) {
+				con.disconnect();
+			}
+		} catch (Exception e) {
+			throw e;
+		}
+	}
+
+	private String uriMapToString(Map<String, String> paramMap) {
+		Set<String> set = paramMap.keySet();
+		StringBuffer postedData = new StringBuffer();
+		for (Iterator<String> it = set.iterator(); it.hasNext();) {
+			String key = it.next();
+			String value = paramMap.get(key) == null ? "" : paramMap.get(key);
+			postedData.append(key);
+			postedData.append("=");
+			try {
+				postedData.append(URLEncoder.encode(value, "UTF-8"));
+			} catch (UnsupportedEncodingException e) {
+				e.printStackTrace();
+			}
+			postedData.append("&");
+		}
+		if (postedData.length() > 0) {
+			postedData.deleteCharAt(postedData.length() - 1);// 删除末尾分隔符
+		}
+		return postedData.toString();
+	}
+}

--- a/datax-web-sdk/src/main/resources/sdk-config.properties
+++ b/datax-web-sdk/src/main/resources/sdk-config.properties
@@ -1,0 +1,22 @@
+#应用接入标识
+datax.web.admin.accessKey=vCTez6oi
+#应用接入密钥
+datax.web.admin.secretKey=f2062d38fb964fbec889168a6adfd01adeedf880
+# datax-web调度器访问路径
+datax.web.admin.url=http://127.0.0.1:8080
+# datax-web任务执行器id
+datax.web.admin.jobGroup=1
+# datax-web新增任务API
+datax.web.admin.api.add=/api/job/add
+# datax-web更新任务API
+datax.web.admin.api.update=/api/job/update
+# datax-web删除任务API
+datax.web.admin.api.delete=/api/job/remove
+# datax-web启用任务API
+datax.web.admin.api.start=/api/job/start
+# datax-web停用任务API
+datax.web.admin.api.stop=/api/job/stop
+# datax-web查看任务API
+datax.web.admin.api.loadJob=/api/job/loadJob
+# datax-web查看任务执行记录API
+datax.web.admin.api.log=/api/log/pageList

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,8 @@
         <module>datax-executor</module>
         <module>datax-rpc</module>
         <module>datax-assembly</module>
+        <module>datax-web-sdk-spring-boot-starter</module>
+        <module>datax-web-sdk</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
一、从用户管理获取AccessKey和SecretKey
![图片](https://user-images.githubusercontent.com/16129287/96249238-7cbfcb80-0fdf-11eb-8ad4-9619791606da.png)

二、第三方应用引入starter包
```
<dependency>
    <groupId>com.wugui</groupId>
    <artifactId>datax-web-sdk-spring-boot-starter</artifactId>
    <version>2.1.2</version>
</dependency>
```

三、增加配置文件
![图片](https://user-images.githubusercontent.com/16129287/96249545-e9d36100-0fdf-11eb-987e-57b0e917a9f5.png)

四、引入bean
```
@Autowired
private JobClient jobClient;
```

五、使用
用例见 datax-web-sdk-spring-boot-starter/src/test/java/ClientTest.java

前端代码已提交 https://github.com/WeiYe-Jing/datax-web-ui/pull/28