### PR TITLE
查询最大 ID 时候不应该提供默认值

### DIFF
--- a/datax-admin/src/main/java/com/wugui/datax/admin/tool/query/BaseQueryTool.java
+++ b/datax-admin/src/main/java/com/wugui/datax/admin/tool/query/BaseQueryTool.java
@@ -446,7 +446,7 @@ public abstract class BaseQueryTool implements QueryToolInterface {
     public long getMaxIdVal(String tableName, String primaryKey) {
         Statement stmt = null;
         ResultSet rs = null;
-        long maxVal = 0;
+        Long maxVal = null;
         try {
             stmt = connection.createStatement();
             //获取sql


### PR DESCRIPTION
在同步模式为 ID 自增模式时候，捕获异常会导致获取到的 ID 为 0
造成同步任务 ID 回环,经历 MaxID,0 --> 0,0 --> 0,MaxId
造成全表同步，主键冲突问题，应该让 trigger 获取最大 ID 异常而失败