### PR TITLE
添加hbase数据源，hbase-protocol包依赖异常

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@
 /build/
 /packages/
 /datax-assembly/target/
+.DS_Store
+*.iml

--- a/datax-admin/pom.xml
+++ b/datax-admin/pom.xml
@@ -580,10 +580,10 @@
                     <artifactId>hbase-annotations</artifactId>
                     <groupId>org.apache.hbase</groupId>
                 </exclusion>
-                <exclusion>
-                    <artifactId>hbase-protocol</artifactId>
-                    <groupId>org.apache.hbase</groupId>
-                </exclusion>
+<!--                <exclusion>-->
+<!--                    <artifactId>hbase-protocol</artifactId>-->
+<!--                    <groupId>org.apache.hbase</groupId>-->
+<!--                </exclusion>-->
                 <exclusion>
                     <artifactId>jackson-mapper-asl</artifactId>
                     <groupId>org.codehaus.jackson</groupId>

--- a/datax-admin/src/main/java/com/wugui/datax/admin/tool/query/HBaseQueryTool.java
+++ b/datax-admin/src/main/java/com/wugui/datax/admin/tool/query/HBaseQueryTool.java
@@ -70,8 +70,9 @@ public class HBaseQueryTool {
      */
     public boolean dataSourceTest() throws IOException {
         Admin admin = connection.getAdmin();
-        HTableDescriptor[] tableDescriptor = admin.listTables();
-        return tableDescriptor.length > 0;
+        NamespaceDescriptor[] descriptors = admin.listNamespaceDescriptors();
+        //HTableDescriptor[] tableDescriptor = admin.listTables();
+        return descriptors.length > 0;
     }
 
     /**


### PR DESCRIPTION
添加hbase作为数据源时 ，测试连接报错如下：
java.lang.NoClassDefFoundError: org/apache/hadoop/hbase/protobuf/generated/MasterProtos$MasterService$BlockingInterface

经过调试发现时hbase-client去掉了‘hbase-protocol’依赖。