### PR TITLE
add dependency for JDK11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,13 @@
         <module>datax-rpc</module>
         <module>datax-assembly</module>
     </modules>
+     <dependencies>
+            <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>jsr250-api</artifactId>
+            <version>1.0</version>
+    </dependency>
+    </dependencies>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Ubuntu20.04 APT源中默认的JDK版本太高（JDK11），需要添加依赖javax.annotation