### PR TITLE
fix: 测试数据源连接不使用缓存，解决#664

### DIFF
--- a/datax-admin/src/main/java/com/wugui/datax/admin/entity/JobDatasource.java
+++ b/datax-admin/src/main/java/com/wugui/datax/admin/entity/JobDatasource.java
@@ -131,6 +131,9 @@ public class JobDatasource extends Model<JobDatasource> {
      */
     @ApiModelProperty(value = "数据库名", hidden = true)
     private String databaseName;
+
+    @TableField(exist = false)
+    private Boolean isCache = true;
     /**
      * 获取主键值
      *

--- a/datax-admin/src/main/java/com/wugui/datax/admin/service/impl/JobDatasourceServiceImpl.java
+++ b/datax-admin/src/main/java/com/wugui/datax/admin/service/impl/JobDatasourceServiceImpl.java
@@ -29,6 +29,8 @@ public class JobDatasourceServiceImpl extends ServiceImpl<JobDatasourceMapper, J
 
     @Override
     public Boolean  dataSourceTest(JobDatasource jobDatasource) throws IOException {
+        // 测试连接的时候不使用缓存， 否则名称相同时， 获取的是缓存中的连接
+        jobDatasource.setIsCache(Boolean.FALSE);
         if (JdbcConstants.HBASE.equals(jobDatasource.getDatasource())) {
             return new HBaseQueryTool(jobDatasource).dataSourceTest();
         }

--- a/datax-admin/src/main/java/com/wugui/datax/admin/tool/query/BaseQueryTool.java
+++ b/datax-admin/src/main/java/com/wugui/datax/admin/tool/query/BaseQueryTool.java
@@ -16,6 +16,7 @@ import com.wugui.datax.admin.util.JdbcConstants;
 import com.wugui.datax.admin.util.JdbcUtils;
 import com.zaxxer.hikari.HikariDataSource;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.BooleanUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,7 +58,7 @@ public abstract class BaseQueryTool implements QueryToolInterface {
      * @param jobDatasource
      */
     BaseQueryTool(JobDatasource jobDatasource) throws SQLException {
-        if (LocalCacheUtil.get(jobDatasource.getDatasourceName()) == null) {
+        if (LocalCacheUtil.get(jobDatasource.getDatasourceName()) == null || BooleanUtils.isNotTrue(jobDatasource.getIsCache())) {
             getDataSource(jobDatasource);
         } else {
             this.connection = (Connection) LocalCacheUtil.get(jobDatasource.getDatasourceName());

--- a/datax-admin/src/main/java/com/wugui/datax/admin/tool/query/HBaseQueryTool.java
+++ b/datax-admin/src/main/java/com/wugui/datax/admin/tool/query/HBaseQueryTool.java
@@ -4,6 +4,7 @@ package com.wugui.datax.admin.tool.query;
 import com.wugui.datatx.core.util.Constants;
 import com.wugui.datax.admin.core.util.LocalCacheUtil;
 import com.wugui.datax.admin.entity.JobDatasource;
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.*;
 import org.apache.hadoop.hbase.client.*;
@@ -25,7 +26,7 @@ public class HBaseQueryTool {
     private Table table;
 
     public HBaseQueryTool(JobDatasource jobDatasource) throws IOException {
-        if (LocalCacheUtil.get(jobDatasource.getDatasourceName()) == null) {
+        if (LocalCacheUtil.get(jobDatasource.getDatasourceName()) == null || BooleanUtils.isNotTrue(jobDatasource.getIsCache())) {
             getDataSource(jobDatasource);
         } else {
             connection = (Connection) LocalCacheUtil.get(jobDatasource.getDatasourceName());

--- a/datax-admin/src/main/java/com/wugui/datax/admin/tool/query/Hbase20XsqlQueryTool.java
+++ b/datax-admin/src/main/java/com/wugui/datax/admin/tool/query/Hbase20XsqlQueryTool.java
@@ -1,19 +1,13 @@
 package com.wugui.datax.admin.tool.query;
 
 import com.google.common.collect.Lists;
-import com.mongodb.MongoClient;
-import com.mongodb.MongoClientURI;
-import com.mongodb.MongoCredential;
 import com.wugui.datax.admin.core.util.LocalCacheUtil;
 import com.wugui.datax.admin.entity.JobDatasource;
-import com.wugui.datax.admin.tool.database.ColumnInfo;
 import com.wugui.datax.admin.util.JdbcUtils;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.BooleanUtils;
 
-import java.io.IOException;
 import java.sql.*;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -32,7 +26,8 @@ public class Hbase20XsqlQueryTool extends BaseQueryTool implements QueryToolInte
     public Hbase20XsqlQueryTool(JobDatasource jobJdbcDatasource) throws SQLException {
         super(jobJdbcDatasource);
 
-        if (LocalCacheUtil.get(jobJdbcDatasource.getDatasourceName()) == null) {
+        if (LocalCacheUtil.get(jobJdbcDatasource.getDatasourceName()) == null
+                || BooleanUtils.isNotTrue(jobJdbcDatasource.getIsCache())) {
             getDataSource(jobJdbcDatasource);
         } else {
             conn = (Connection) LocalCacheUtil.get(jobJdbcDatasource.getDatasourceName());

--- a/datax-admin/src/main/java/com/wugui/datax/admin/tool/query/MongoDBQueryTool.java
+++ b/datax-admin/src/main/java/com/wugui/datax/admin/tool/query/MongoDBQueryTool.java
@@ -7,6 +7,7 @@ import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.MongoIterable;
 import com.wugui.datax.admin.core.util.LocalCacheUtil;
 import com.wugui.datax.admin.entity.JobDatasource;
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.bson.Document;
 
@@ -25,7 +26,7 @@ public class MongoDBQueryTool {
 
 
     public MongoDBQueryTool(JobDatasource jobDatasource) throws IOException {
-        if (LocalCacheUtil.get(jobDatasource.getDatasourceName()) == null) {
+        if (LocalCacheUtil.get(jobDatasource.getDatasourceName()) == null || BooleanUtils.isNotTrue(jobDatasource.getIsCache())) {
             getDataSource(jobDatasource);
         } else {
             connection = (MongoClient) LocalCacheUtil.get(jobDatasource.getDatasourceName());


### PR DESCRIPTION
问题描述： https://github.com/WeiYe-Jing/datax-web/issues/664
主要问题是因为在获取数据源连接时， 默认全部是使用缓存
![image](https://github.com/WeiYe-Jing/datax-web/assets/99388822/2fc8806b-6be6-4ef7-a0a4-b564f7eb15af)
修复方法： 数据源测试不使用缓存， 其他情况照常使用缓存， 解决方法如下：
1. 添加isCache字段， 默认为true， 表示使用缓存
![image](https://github.com/WeiYe-Jing/datax-web/assets/99388822/547d96a5-f2cc-48e0-8c6a-fd30b5631979)

2. 在获取数据源连接时添加判断， 因为有默认值的存在， 所以其他方法获取数据源连接时和之前时一样的
![image](https://github.com/WeiYe-Jing/datax-web/assets/99388822/550657ee-e1f3-4150-b597-295d4d337549)


3. 修改数据源连接为不从缓存中获取
![image](https://github.com/WeiYe-Jing/datax-web/assets/99388822/024888e6-abd4-4541-9435-7d391a8304ac)

